### PR TITLE
more stable tests

### DIFF
--- a/tests/features/active_nodes.feature
+++ b/tests/features/active_nodes.feature
@@ -60,7 +60,7 @@ Feature: mysync saves quorum hosts in zk
     Given cluster environment is
     """
     MYSYNC_FAILOVER=true
-    MYSYNC_FAILOVER_DELAY=0s
+    MYSYNC_FAILOVER_DELAY=3s
     MYSYNC_FAILOVER_COOLDOWN=0s
     """
     Given cluster is up and running
@@ -102,7 +102,7 @@ Feature: mysync saves quorum hosts in zk
     Given cluster environment is
     """
     MYSYNC_FAILOVER=true
-    MYSYNC_FAILOVER_DELAY=0s
+    MYSYNC_FAILOVER_DELAY=3s
     MYSYNC_FAILOVER_COOLDOWN=0s
     """
     Given cluster is up and running

--- a/tests/features/async.feature
+++ b/tests/features/async.feature
@@ -6,7 +6,6 @@ Feature: mysync should work without semi-sync replication
       MYSYNC_SEMISYNC=false
       """
     Given cluster is up and running
-    When I wait for "10" seconds
     Then zookeeper node "/test/active_nodes" should match json_exactly within "20" seconds
       """
       ["mysql1","mysql2","mysql3"]
@@ -89,11 +88,10 @@ Feature: mysync should work without semi-sync replication
       """
       MYSYNC_FAILOVER=true
       MYSYNC_SEMISYNC=false
-      MYSYNC_FAILOVER_DELAY=0s
+      MYSYNC_FAILOVER_DELAY=3s
       MYSYNC_FAILOVER_COOLDOWN=0s
       """
     Given cluster is up and running
-    When I wait for "10" seconds
     Then zookeeper node "/test/active_nodes" should match json_exactly within "20" seconds
       """
       ["mysql1","mysql2","mysql3"]

--- a/tests/features/failover.feature
+++ b/tests/features/failover.feature
@@ -5,7 +5,7 @@ Feature: failover
     Given cluster environment is
       """
       MYSYNC_FAILOVER=true
-      MYSYNC_FAILOVER_DELAY=0s
+      MYSYNC_FAILOVER_DELAY=3s
       """
 
     Scenario: failover works
@@ -277,7 +277,7 @@ Feature: failover
       Given cluster environment is
         """
         MYSYNC_FAILOVER=true
-        MYSYNC_FAILOVER_DELAY=0s
+        MYSYNC_FAILOVER_DELAY=3s
         MYSYNC_FAILOVER_COOLDOWN=0s
         """
       Given cluster is up and running
@@ -329,7 +329,7 @@ Feature: failover
     Given cluster environment is
     """
     MYSYNC_FAILOVER=true
-    MYSYNC_FAILOVER_DELAY=0s
+    MYSYNC_FAILOVER_DELAY=3s
     MYSYNC_FAILOVER_COOLDOWN=0s
     """
     Given cluster is up and running
@@ -398,7 +398,7 @@ Feature: failover
     Given cluster environment is
     """
     MYSYNC_FAILOVER=true
-    MYSYNC_FAILOVER_DELAY=0s
+    MYSYNC_FAILOVER_DELAY=3s
     MYSYNC_FAILOVER_COOLDOWN=0s
     """
     Given cluster is up and running

--- a/tests/features/host_discovery.feature
+++ b/tests/features/host_discovery.feature
@@ -35,6 +35,7 @@ Feature: mysync use keys in zk properly
     Given cluster environment is
       """
       MYSYNC_FAILOVER=true
+      MYSYNC_FAILOVER_DELAY=3s
       """
     Given cluster is up and running
     Then zookeeper node "/test/active_nodes" should match json_exactly within "30" seconds

--- a/tests/features/readonly_filesystem.feature
+++ b/tests/features/readonly_filesystem.feature
@@ -1,8 +1,9 @@
 Feature: readonly filesystem
-  Scenario: check master failture when disk on muster become readonly
+  Scenario: check master failure when disk on master become readonly
     Given cluster environment is
         """
         MYSYNC_FAILOVER=true
+        MYSYNC_FAILOVER_DELAY=3s
         MYSYNC_FAILOVER_COOLDOWN=0s
         """
     Given cluster is up and running

--- a/tests/features/recovery.feature
+++ b/tests/features/recovery.feature
@@ -4,7 +4,7 @@ Feature: hosts recovery
       Given cluster environment is
         """
         MYSYNC_FAILOVER=true
-        MYSYNC_FAILOVER_DELAY=0s
+        MYSYNC_FAILOVER_DELAY=3s
         MYSYNC_FAILOVER_COOLDOWN=0s
         """
       Given cluster is up and running

--- a/tests/features/zk_failure.feature
+++ b/tests/features/zk_failure.feature
@@ -2,6 +2,10 @@ Feature: mysync handles zookeeper lost
 
   Scenario: mysync handles single rack network issue that could lead to split brain
     Given cluster is up and running
+    And zookeeper node "/test/active_nodes" should match json_exactly within "30" seconds
+    """
+    ["mysql1","mysql2","mysql3"]
+    """
     Then mysql host "mysql1" should be master
     And mysql host "mysql1" should be writable
     And mysql host "mysql2" should be replica of "mysql1"
@@ -37,6 +41,10 @@ Feature: mysync handles zookeeper lost
 
   Scenario: mysync handles ZK failure - do nothing
     Given cluster is up and running
+    And zookeeper node "/test/active_nodes" should match json_exactly within "30" seconds
+    """
+    ["mysql1","mysql2","mysql3"]
+    """
     Then mysql host "mysql1" should be master
     And mysql host "mysql1" should be writable
     And mysql host "mysql2" should be replica of "mysql1"
@@ -65,6 +73,10 @@ Feature: mysync handles zookeeper lost
     MYSYNC_DB_LOST_CHECK_TIMEOUT=3s
     """
     Given cluster is up and running
+    And zookeeper node "/test/active_nodes" should match json_exactly within "30" seconds
+    """
+    ["mysql1","mysql2","mysql3"]
+    """
 
     Then mysql host "mysql1" should be master
     And mysql host "mysql1" should become writable within "5" seconds

--- a/tests/mysync_test.go
+++ b/tests/mysync_test.go
@@ -501,7 +501,8 @@ func (tctx *testContext) stepRunHeavyUserRequests(host string, sleepTime int) er
 			"sleep_time": sleepTime,
 		}, timeout)
 		if err != nil {
-			fmt.Printf("error while running heavy requests %v\n", err)
+			fmt.Printf("error while running heavy requests: %v\n", err)
+			tctx.sqlUserQueryError.Store(host, err)
 		}
 	}()
 
@@ -526,7 +527,8 @@ func (tctx *testContext) stepRunHeavyReadUserRequests(host string, sleepTime int
 			"sleep_time": sleepTime,
 		}, timeout)
 		if err != nil {
-			fmt.Printf("error while running long read requests %v\n", err)
+			fmt.Printf("error while running long read requests: %v\n", err)
+			tctx.sqlUserQueryError.Store(host, err)
 		}
 	}()
 


### PR DESCRIPTION
Fixed "ZK failure" test case, when cluster nodes did not have time to become active.
Fixed error handling in "run heavy user requests" step.