### PR TITLE
fix: semi sync does not turn off on the old master

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -907,6 +907,7 @@ func (app *App) calcActiveNodesChanges(clusterState map[string]*NodeState, activ
 			if dataLag > app.config.SemiSyncEnableLag {
 				app.logger.Warnf("calc active nodes: %v should become active, but it has data lag %d, delaying...", host, dataLag)
 				dataLagging = append(dataLagging, host)
+				becomeInactive = append(becomeInactive, host)
 			}
 		}
 		becomeActive = filterOut(becomeActive, dataLagging)


### PR DESCRIPTION
The old master may not pick up the binlog file from the master because of this, a large data lag appears. Before that, such replicas did not belong to the becomeInactive category, now they will and semi sync will be turned off correctly on the old master