### PR TITLE
Apache Zookeeper download link fix

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -37,11 +37,9 @@ func TouchFile(fname string) error {
 	_, err := os.Stat(fname)
 	if os.IsNotExist(err) {
 		err := os.WriteFile(fname, []byte(""), 0644)
-		//file, err := os.Create(fname)
 		if err != nil {
 			return err
 		}
-		//defer file.Close()
 	}
 	return nil
 }

--- a/tests/images/base/setup.sh
+++ b/tests/images/base/setup.sh
@@ -74,5 +74,5 @@ cp /var/lib/dist/base/supervisor.conf /etc/supervisor/supervisord.conf
 cp /var/lib/dist/base/supervisor_ssh.conf /etc/supervisor/conf.d
 
 # zookeeper
-wget -nc -O - --quiet  https://downloads.apache.org/zookeeper/zookeeper-${ZK_VERSION}/apache-zookeeper-${ZK_VERSION}-bin.tar.gz | tar -xz -C /opt && \
+wget -nc -O - --quiet https://archive.apache.org/dist/zookeeper/zookeeper-${ZK_VERSION}/apache-zookeeper-${ZK_VERSION}-bin.tar.gz | tar -xz -C /opt && \
 mv /opt/apache-zookeeper* /opt/zookeeper


### PR DESCRIPTION
Issue:
3.7.1 version of Apache Zookeeper, which is used in tests, was moved to the archives.

Failed tests:
- [Failed test - mysql 8.0](https://github.com/yandex/mysync/actions/runs/6483012385/job/17604723760)
- [Failed test - mysql 5.7](https://github.com/yandex/mysync/actions/runs/6483012383/job/17603676800)