### PR TITLE
Bug fix for replication repair on long queries

### DIFF
--- a/internal/app/replication.go
+++ b/internal/app/replication.go
@@ -41,7 +41,7 @@ func (app *App) MarkReplicationRunning(node *mysql.Node, channel string) {
 		newGtidSet := gtids.ParseGtidSet(status.GetExecutedGtidSet())
 		oldGtidSet := gtids.ParseGtidSet(replState.LastGTIDExecuted)
 
-		if !isGTIDLessOrEqual(oldGtidSet, newGtidSet) {
+		if !isGTIDLessOrEqual(newGtidSet, oldGtidSet) {
 			delete(app.replRepairState, key)
 		}
 	}


### PR DESCRIPTION
When a long query runs on a replication with an error, then mysync
1. Tries to repair it with some algorithm.
2. Waits some time.
3. Checks that IO and SQL are running.
4. It thinks that replication is fixed, but in fact, when replaying such a transaction, replication may break again. This will be repeated forever until someone notices the mistake.

Detailed steps to reproduce: https://gist.github.com/noname0443/d2a42845dc34a39c9a34a038f0b974cd

I changed the repair algorithm:
1. Remember the current GTID for the channel we want to repair.
2. Try to repair it with some algorithm.
3. Wait for some time.
4. Check that IO and SQL are running and GTID has changed.
5. Replication is fixed.