### PR TITLE
restart only replicas ahead of the master

### DIFF
--- a/internal/app/replication.go
+++ b/internal/app/replication.go
@@ -41,7 +41,7 @@ func (app *App) MarkReplicationRunning(node *mysql.Node, channel string) {
 		newGtidSet := gtids.ParseGtidSet(status.GetExecutedGtidSet())
 		oldGtidSet := gtids.ParseGtidSet(replState.LastGTIDExecuted)
 
-		if !gtids.IsSlaveBehindOrEqual(newGtidSet, oldGtidSet) {
+		if gtids.IsSlaveAhead(newGtidSet, oldGtidSet) {
 			delete(app.replRepairState, key)
 		}
 	}

--- a/internal/app/replication.go
+++ b/internal/app/replication.go
@@ -41,7 +41,7 @@ func (app *App) MarkReplicationRunning(node *mysql.Node, channel string) {
 		newGtidSet := gtids.ParseGtidSet(status.GetExecutedGtidSet())
 		oldGtidSet := gtids.ParseGtidSet(replState.LastGTIDExecuted)
 
-		if !isGTIDLessOrEqual(newGtidSet, oldGtidSet) {
+		if !gtids.IsSlaveBehindOrEqual(newGtidSet, oldGtidSet) {
 			delete(app.replRepairState, key)
 		}
 	}

--- a/internal/app/util.go
+++ b/internal/app/util.go
@@ -226,7 +226,8 @@ func isSlavePermanentlyLost(sstatus mysql.ReplicaStatus, masterGtidSet gtids.GTI
 		return true
 	}
 	slaveGtidSet := gtids.ParseGtidSet(sstatus.GetExecutedGtidSet())
-	return !gtids.IsSlaveBehindOrEqual(slaveGtidSet, masterGtidSet)
+	// TODO: why ahead = lost?..
+	return gtids.IsSlaveAhead(slaveGtidSet, masterGtidSet)
 }
 
 func validatePriority(priority *int64) error {

--- a/internal/app/util.go
+++ b/internal/app/util.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
-	"github.com/google/uuid"
 	"github.com/yandex/mysync/internal/log"
 	"github.com/yandex/mysync/internal/mysql"
 	"github.com/yandex/mysync/internal/mysql/gtids"
@@ -228,34 +226,7 @@ func isSlavePermanentlyLost(sstatus mysql.ReplicaStatus, masterGtidSet gtids.GTI
 		return true
 	}
 	slaveGtidSet := gtids.ParseGtidSet(sstatus.GetExecutedGtidSet())
-	return !isGTIDLessOrEqual(slaveGtidSet, masterGtidSet)
-}
-
-func isGTIDLessOrEqual(slaveGtidSet, masterGtidSet gtids.GTIDSet) bool {
-	return masterGtidSet.Contain(slaveGtidSet) || masterGtidSet.Equal(slaveGtidSet)
-}
-
-func isSplitBrained(slaveGtidSet, masterGtidSet gtids.GTIDSet, masterUUID uuid.UUID) bool {
-	mysqlSlaveGtidSet := slaveGtidSet.(*gomysql.MysqlGTIDSet)
-	mysqlMasterGtidSet := masterGtidSet.(*gomysql.MysqlGTIDSet)
-	for _, slaveSet := range mysqlSlaveGtidSet.Sets {
-		masterSet, ok := mysqlMasterGtidSet.Sets[slaveSet.SID.String()]
-		if !ok {
-			return true
-		}
-
-		if masterSet.Contain(slaveSet) {
-			continue
-		}
-
-		if masterSet.SID == masterUUID {
-			continue
-		}
-
-		return true
-	}
-
-	return false
+	return !gtids.IsSlaveBehindOrEqual(slaveGtidSet, masterGtidSet)
 }
 
 func validatePriority(priority *int64) error {

--- a/internal/mysql/gtids/utils.go
+++ b/internal/mysql/gtids/utils.go
@@ -1,0 +1,37 @@
+package gtids
+
+import (
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/google/uuid"
+)
+
+func IsSlaveBehindOrEqual(slaveGtidSet, masterGtidSet GTIDSet) bool {
+	return masterGtidSet.Contain(slaveGtidSet) || masterGtidSet.Equal(slaveGtidSet)
+}
+
+func IsSlaveAhead(slaveGtidSet, masterGtidSet GTIDSet) bool {
+	return !IsSlaveBehindOrEqual(slaveGtidSet, masterGtidSet)
+}
+
+func IsSplitBrained(slaveGtidSet, masterGtidSet GTIDSet, masterUUID uuid.UUID) bool {
+	mysqlSlaveGtidSet := slaveGtidSet.(*gomysql.MysqlGTIDSet)
+	mysqlMasterGtidSet := masterGtidSet.(*gomysql.MysqlGTIDSet)
+	for _, slaveSet := range mysqlSlaveGtidSet.Sets {
+		masterSet, ok := mysqlMasterGtidSet.Sets[slaveSet.SID.String()]
+		if !ok {
+			return true
+		}
+
+		if masterSet.Contain(slaveSet) {
+			continue
+		}
+
+		if masterSet.SID == masterUUID {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}

--- a/internal/mysql/gtids/wrapper.go
+++ b/internal/mysql/gtids/wrapper.go
@@ -6,7 +6,7 @@ import (
 
 type GTIDSet = mysql.GTIDSet
 
-func ParseGtidSet(gtidset string) mysql.GTIDSet {
+func ParseGtidSet(gtidset string) GTIDSet {
 	parsed, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, gtidset)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
# restart only replicas ahead of the master

### Describe what this PR fix
When replicas return to active nodes it may be streaming binlog. If binlog is big enough and we restart replication - we will interrupt download process. So we should restart only replicas ahead, as they have all required binary logs