### PR TITLE
Fix switchover when many connections appear

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ replication_repair_max_attempts: 3
 
 external_replication_type: off
 show_only_gtid_diff: False
+force_switchover: False
 ```
 
 ### Usage

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1212,14 +1212,12 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 		if app.config.ForceSwitchover {
 			err := node.SetOffline()
 			if err != nil {
-				app.logger.Infof("switchover: failed to set node %s offline: %v", host, err)
-				return fmt.Errorf("failed to set node %s read-only: %v", host, err)
+				return fmt.Errorf("switchover: failed to set node %s offline: %v", host, err)
 			}
 
 			err = node.SemiSyncDisable()
 			if err != nil {
-				app.logger.Infof("switchover: failed to disable semi-sync on node %s: %v", host, err)
-				return fmt.Errorf("failed to set node %s read-only: %v", host, err)
+				return fmt.Errorf("switchover: failed to disable semi-sync on node %s: %v", host, err)
 			}
 		}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1210,8 +1210,17 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 		// in case node is a master
 
 		if app.config.ForceSwitchover {
-			node.SetOfflineForce()
-			defer node.SetOnline()
+			err := node.SetOfflineForce()
+			if err != nil {
+				return fmt.Errorf("failed to set node %s force offline: %v", host, err)
+			}
+
+			defer func() {
+				err := node.SetOnline()
+				if err != nil {
+					app.logger.Errorf("failed to set node %s online after setting force offline: %v", host, err)
+				}
+			}()
 		}
 
 		err := node.SetReadOnly(true)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1208,6 +1208,21 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 		}
 		node := app.cluster.Get(host)
 		// in case node is a master
+
+		if app.config.ForceSwitchover {
+			err := node.SetOffline()
+			if err != nil {
+				app.logger.Infof("switchover: failed to set node %s offline: %v", host, err)
+				return fmt.Errorf("failed to set node %s read-only: %v", host, err)
+			}
+
+			err = node.SemiSyncDisable()
+			if err != nil {
+				app.logger.Infof("switchover: failed to disable semi-sync on node %s: %v", host, err)
+				return fmt.Errorf("failed to set node %s read-only: %v", host, err)
+			}
+		}
+
 		err := node.SetReadOnly(true)
 		if err != nil || app.emulateError("freeze_ro") {
 			app.logger.Infof("switchover: failed to set node %s read-only, trying kill bad queries: %v", host, err)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1210,15 +1210,8 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 		// in case node is a master
 
 		if app.config.ForceSwitchover {
-			err := node.SetOffline()
-			if err != nil {
-				return fmt.Errorf("switchover: failed to set node %s offline: %v", host, err)
-			}
-
-			err = node.SemiSyncDisable()
-			if err != nil {
-				return fmt.Errorf("switchover: failed to disable semi-sync on node %s: %v", host, err)
-			}
+			node.SetOfflineForce()
+			defer node.SetOnline()
 		}
 
 		err := node.SetReadOnly(true)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,7 +97,7 @@ type Config struct {
 	ReplMonErrorWaitInterval                time.Duration                `config:"repl_mon_error_wait_interval" yaml:"repl_mon_error_wait_interval"`
 	ReplMonSlaveWaitInterval                time.Duration                `config:"repl_mon_slave_wait_interval" yaml:"repl_mon_slave_wait_interval"`
 	ShowOnlyGTIDDiff                        bool                         `config:"show_only_gtid_diff" yaml:"show_only_gtid_diff"`
-	ForceSwitchover                         bool                         `config:"force_switchover" yaml:"force_switchover"`
+	ForceSwitchover                         bool                         `config:"force_switchover" yaml:"force_switchover"` // TODO: Remove when we will be sure it's right way to do switchover
 }
 
 // DefaultConfig returns default configuration for MySync

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ type Config struct {
 	ReplMonErrorWaitInterval                time.Duration                `config:"repl_mon_error_wait_interval" yaml:"repl_mon_error_wait_interval"`
 	ReplMonSlaveWaitInterval                time.Duration                `config:"repl_mon_slave_wait_interval" yaml:"repl_mon_slave_wait_interval"`
 	ShowOnlyGTIDDiff                        bool                         `config:"show_only_gtid_diff" yaml:"show_only_gtid_diff"`
+	ForceSwitchover                         bool                         `config:"force_switchover" yaml:"force_switchover"`
 }
 
 // DefaultConfig returns default configuration for MySync
@@ -182,6 +183,7 @@ func DefaultConfig() (Config, error) {
 		ReplMonErrorWaitInterval:                10 * time.Second,
 		ReplMonSlaveWaitInterval:                10 * time.Second,
 		ShowOnlyGTIDDiff:                        false,
+		ForceSwitchover:                         false,
 	}
 	return config, nil
 }

--- a/internal/mysql/node.go
+++ b/internal/mysql/node.go
@@ -833,6 +833,20 @@ func (n *Node) SetOnline() error {
 	return n.exec(queryDisableOfflineMode, nil)
 }
 
+func (n *Node) SetOfflineForce() error {
+	err := n.SemiSyncDisable()
+	if err != nil {
+		return fmt.Errorf("failed to disable semi-sync on node %s: %v", n.host, err)
+	}
+
+	err = n.SetOffline()
+	if err != nil {
+		return fmt.Errorf("failed to set node %s offline: %v", n.host, err)
+	}
+
+	return nil
+}
+
 // ChangeMaster changes master of MySQL Node, demoting it to slave
 func (n *Node) ChangeMaster(host string) error {
 	useSsl := 0

--- a/internal/mysql/node.go
+++ b/internal/mysql/node.go
@@ -836,15 +836,9 @@ func (n *Node) SetOnline() error {
 func (n *Node) SetOfflineForce() error {
 	err := n.SemiSyncDisable()
 	if err != nil {
-		return fmt.Errorf("failed to disable semi-sync on node %s: %v", n.host, err)
+		return err
 	}
-
-	err = n.SetOffline()
-	if err != nil {
-		return fmt.Errorf("failed to set node %s offline: %v", n.host, err)
-	}
-
-	return nil
+	return n.SetOffline()
 }
 
 // ChangeMaster changes master of MySQL Node, demoting it to slave

--- a/tests/features/switchover_from.feature
+++ b/tests/features/switchover_from.feature
@@ -37,46 +37,11 @@ Feature: manual switchover from old master
       }
       """
 
-  Scenario: if switchover was approved, it will not be rejected
-    Given cluster is up and running
-    Then zookeeper node "/test/active_nodes" should match json_exactly within "20" seconds
-      """
-      ["mysql1","mysql2","mysql3"]
-      """
-    When mysql on host "mysql3" is killed
-    And mysql on host "mysql2" is killed
-    And I set zookeeper node "/test/switch" to
-      """
-      {
-          "from": "mysql1",
-          "to": "",
-          "cause": "manual",
-          "initiated_by": "mysql1",
-          "run_count": 1
-      }
-      """
-    Then zookeeper node "/test/last_switch" should not exist within "30" seconds  
-    Then zookeeper node "/test/last_rejected_switch" should not exist within "30" seconds  
-    When mysql on host "mysql3" is started
-    And mysql on host "mysql2" is started
-    Then zookeeper node "/test/last_switch" should match json within "30" seconds
-      """
-      {
-          "from": "mysql1",
-          "to": "",
-          "cause": "manual",
-          "initiated_by": "mysql1",
-          "result": {
-              "ok": true
-          }
-      }
-      """
-
-  Scenario: force switchover works from
+  Scenario Outline: if switchover was approved, it will not be rejected
     Given cluster environment is
-    """
-    FORCE_SWITCHOVER=true
-    """
+      """
+      FORCE_SWITCHOVER=<force_switchover>
+      """
     Given cluster is up and running
     Then zookeeper node "/test/active_nodes" should match json_exactly within "20" seconds
       """
@@ -110,6 +75,10 @@ Feature: manual switchover from old master
           }
       }
       """
+    Examples:
+      | force_switchover  |
+      | true              |
+      | false             |
 
   Scenario Outline: switchover from works on healthy cluster
     Given cluster environment is

--- a/tests/features/switchover_from.feature
+++ b/tests/features/switchover_from.feature
@@ -72,6 +72,45 @@ Feature: manual switchover from old master
       }
       """
 
+  Scenario: force switchover works from
+    Given cluster environment is
+    """
+    FORCE_SWITCHOVER=true
+    """
+    Given cluster is up and running
+    Then zookeeper node "/test/active_nodes" should match json_exactly within "20" seconds
+      """
+      ["mysql1","mysql2","mysql3"]
+      """
+    When mysql on host "mysql3" is killed
+    And mysql on host "mysql2" is killed
+    And I set zookeeper node "/test/switch" to
+      """
+      {
+          "from": "mysql1",
+          "to": "",
+          "cause": "manual",
+          "initiated_by": "mysql1",
+          "run_count": 1
+      }
+      """
+    Then zookeeper node "/test/last_switch" should not exist within "30" seconds  
+    Then zookeeper node "/test/last_rejected_switch" should not exist within "30" seconds  
+    When mysql on host "mysql3" is started
+    And mysql on host "mysql2" is started
+    Then zookeeper node "/test/last_switch" should match json within "30" seconds
+      """
+      {
+          "from": "mysql1",
+          "to": "",
+          "cause": "manual",
+          "initiated_by": "mysql1",
+          "result": {
+              "ok": true
+          }
+      }
+      """
+
   Scenario Outline: switchover from works on healthy cluster
     Given cluster environment is
       """

--- a/tests/features/switchover_to.feature
+++ b/tests/features/switchover_to.feature
@@ -55,6 +55,64 @@ Feature: manual switchover to new master
     And mysql replication on host "mysql3" should run fine within "3" seconds
     And mysql host "mysql3" should be read only
 
+  Scenario: force switchover works to
+    Given cluster environment is
+    """
+    FORCE_SWITCHOVER=true
+    """
+    Given cluster is up and running
+    Then mysql host "mysql1" should be master
+    And mysql host "mysql2" should be replica of "mysql1"
+    And mysql replication on host "mysql2" should run fine within "5" seconds
+    And mysql host "mysql3" should be replica of "mysql1"
+    And mysql replication on host "mysql3" should run fine within "5" seconds
+    And zookeeper node "/test/active_nodes" should match json_exactly within "30" seconds
+    """
+       ["mysql1","mysql2","mysql3"]
+    """
+    When I run heavy user requests on host "mysql1" for "3600" seconds
+    When I run command on host "mysql1"
+      """
+      mysync switch --to mysql2 --wait=0s
+      """
+    Then command return code should be "0"
+    And command output should match regexp
+      """
+      switchover scheduled
+      """
+    And zookeeper node "/test/switch" should match json
+      """
+      {
+        "from": "",
+        "to": "mysql2"
+      }
+      """
+    Then zookeeper node "/test/last_switch" should match json within "120" seconds
+      """
+      {
+        "from": "",
+        "to": "mysql2",
+        "result": {
+          "ok": true
+        }
+      }
+      """
+    Then mysql host "mysql2" should be master
+    And mysql host "mysql2" should have variable "rpl_semi_sync_master_enabled" set to "1"
+    And mysql host "mysql2" should have variable "rpl_semi_sync_slave_enabled" set to "0"
+    And mysql host "mysql2" should be writable
+    And mysql host "mysql1" should be replica of "mysql2"
+    And mysql host "mysql1" should have variable "rpl_semi_sync_slave_enabled" set to "1"
+    And mysql host "mysql1" should have variable "rpl_semi_sync_master_enabled" set to "0"
+    And mysql replication on host "mysql1" should run fine within "3" seconds
+    And mysql host "mysql1" should be read only
+    And mysql host "mysql3" should be replica of "mysql2"
+    And mysql host "mysql3" should have variable "rpl_semi_sync_slave_enabled" set to "1"
+    And mysql host "mysql3" should have variable "rpl_semi_sync_master_enabled" set to "0"
+    And mysql replication on host "mysql3" should run fine within "3" seconds
+    And mysql host "mysql3" should be read only
+
+
   Scenario Outline: switchover to works on healthy cluster
     Given cluster environment is
       """
@@ -274,4 +332,3 @@ Feature: manual switchover to new master
     """
     mysql2 is not active
     """
-

--- a/tests/images/mysql/mysync.yaml
+++ b/tests/images/mysql/mysync.yaml
@@ -62,4 +62,4 @@ replication_channel: ''
 external_replication_type: 'external'
 show_only_gtid_diff: false
 repl_mon: ${REPL_MON:-false}
-force_switchover: false
+force_switchover: ${FORCE_SWITCHOVER:-false}

--- a/tests/images/mysql/mysync.yaml
+++ b/tests/images/mysql/mysync.yaml
@@ -62,3 +62,4 @@ replication_channel: ''
 external_replication_type: 'external'
 show_only_gtid_diff: false
 repl_mon: ${REPL_MON:-false}
+force_switchover: false


### PR DESCRIPTION
# Pull request description

This PR aims to fix the switchover when a lot of connections try to change data. MySync can't kill them fast enough and fails to complete the switchover.

### Please provide steps to reproduce (if it's a bug)

1. Run the script:
```bash
docker rm -f $(docker ps -aq)

cd ../../
GOOS=linux go build -tags netgo,osusergo -o ./tests/images/mysql/mysync ./cmd/mysync/...
docker build --tag=mysync-test-base8.0 tests/images/base --build-arg MYSQL_VERSION=8.0
cd tests/images/
VERSION=8.0 docker-compose up --build -d

docker rm -f images-mysql3-1

docker cp images_zoo1_1:/etc/zk-ssl/ca.cert.pem .
docker cp images_zoo1_1:/etc/zk-ssl/server.crt .
docker cp images_zoo1_1:/etc/zk-ssl/server.key .

docker exec -it images_mysql1_1 mkdir -p /etc/zk-ssl
docker exec -it images_mysql2_1 mkdir -p /etc/zk-ssl

docker cp ca.cert.pem images_mysql1_1:/etc/zk-ssl/
docker cp ca.cert.pem images_mysql2_1:/etc/zk-ssl/

docker cp server.crt images_mysql1_1:/etc/zk-ssl/
docker cp server.crt images_mysql2_1:/etc/zk-ssl/

docker cp server.key images_mysql1_1:/etc/zk-ssl/
docker cp server.key images_mysql2_1:/etc/zk-ssl/

echo "Trying to add mysql1 to mysync..."
while
  timeout -k 70 60 docker exec images_mysql1_1 mysync host add mysql1
  [ $? != 0 ]
do
  echo "Let's try for another time..."
  sleep 2
done

echo "Trying to add mysql2 to mysync..."
while
  timeout -k 70 60 docker exec images_mysql1_1 mysync host add mysql2
  [ $? != 0 ]
do
  echo "Let's try for another time..."
  sleep 2
done

docker exec images_mysql2_1 mysync host add mysql1
docker exec images_mysql2_1 mysync host add mysql2

docker exec images_mysql1_1 mysql -e "CREATE TABLE test1.big_table (id integer, info text);"

docker exec images_mysql1_1 mysql -e "INSERT INTO test1.big_table (id, info) VALUES (1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');"
for ((a = 0; a < 8; a++)); do
  docker exec images_mysql1_1 mysql -e "INSERT INTO test1.big_table SELECT * FROM test1.big_table;"
done

docker exec images_mysql1_1 mysql -e "CREATE USER user1 IDENTIFIED BY 'password';"
docker exec images_mysql1_1 mysql -e "GRANT ALL ON test1.big_table TO user1;"
```
2. Use sysbench with a lot of threads or something like that:
```bash
while true; do
  docker exec images_mysql1_1 mysql -u user1 -ppassword -e "INSERT INTO test1.big_table (id, info) VALUES (SLEEP(1), 'aaaaaaaaaaaaa');" &
  sleep 0.01
done
```
3. Try to do switchover... It will fall.