### PR TITLE
Fix Stringer interface for NodeState

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1813,7 +1813,7 @@ func (app *App) repairCascadeNode(node *mysql.Node, clusterState map[string]*Nod
 	}
 
 	isReplicationRunning := state.SlaveState.ReplicationState == mysql.ReplicationRunning
-	app.logger.Infof("repair: checking cascade node %s. Replication=%v, cnc=%+v, slaveSate=%+v", host, isReplicationRunning, cnc, state.SlaveState)
+	app.logger.Infof("repair: checking cascade node %s. Replication=%v, cnc=%+v, slaveState=%+v", host, isReplicationRunning, cnc, state.String())
 
 	upstreamMaster := state.SlaveState.MasterHost
 	upstreamCandidate := app.findBestStreamFrom(node, clusterState, master, cascadeTopology)
@@ -1882,7 +1882,7 @@ func (app *App) repairCascadeNode(node *mysql.Node, clusterState map[string]*Nod
 		// TODO: replace with IsSplitBrained
 		if gtids.IsSlaveAhead(myGITIDs, candidateGTIDs) && gtids.IsSlaveAhead(candidateGTIDs, myGITIDs) {
 			app.logger.Errorf("repair: %s and %s are splitbrained...", host, upstreamCandidate)
-			app.writeEmergeFile("cascade replica splitbain detected")
+			app.writeEmergeFile("cascade replica splitbrain detected")
 			return
 		}
 		if gtids.IsSlaveBehindOrEqual(myGITIDs, candidateGTIDs) {
@@ -2074,7 +2074,7 @@ func (app *App) getNodeState(host string) *NodeState {
 			return err
 		}
 		if !pingOk {
-			return fmt.Errorf("ping is no ok")
+			return fmt.Errorf("ping is not ok")
 		}
 		nodeState.IsReadOnly, nodeState.IsSuperReadOnly, err = node.IsReadOnly()
 		if err != nil {
@@ -2195,7 +2195,9 @@ func (app *App) getLocalDaemonState() (*DaemonState, error) {
 func (app *App) getClusterStateFromDB() map[string]*NodeState {
 	hosts := app.cluster.AllNodeHosts()
 	getter := func(host string) (*NodeState, error) {
-		return app.getNodeState(host), nil
+		ns := app.getNodeState(host)
+		ns.ShowOnlyGTIDDiff = app.config.ShowOnlyGTIDDiff
+		return ns, nil
 	}
 	clusterState, _ := getNodeStatesInParallel(hosts, getter, app.logger)
 	return clusterState
@@ -2209,6 +2211,7 @@ func (app *App) getClusterStateFromDcs() (map[string]*NodeState, error) {
 		if err != nil && err != dcs.ErrNotFound {
 			return nil, err
 		}
+		nodeState.ShowOnlyGTIDDiff = app.config.ShowOnlyGTIDDiff
 		return nodeState, nil
 	}
 	return getNodeStatesInParallel(hosts, getter, app.logger)

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -80,7 +80,7 @@ func (app *App) CliInfo(short bool) int {
 		}
 		health := make(map[string]interface{})
 		for host, state := range clusterState {
-			health[host] = state.String(app.config.ShowOnlyGTIDDiff)
+			health[host] = state.String()
 		}
 		data[pathHealthPrefix] = health
 
@@ -162,7 +162,7 @@ func (app *App) CliState(short bool) int {
 	if short {
 		clusterStateStrings := make(map[string]string)
 		for host, state := range clusterState {
-			clusterStateStrings[host] = state.String(app.config.ShowOnlyGTIDDiff)
+			clusterStateStrings[host] = state.String()
 		}
 		tree = clusterStateStrings
 	} else {

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -97,6 +97,8 @@ type NodeState struct {
 	MasterState          *MasterState   `json:"master_state"`
 	SlaveState           *SlaveState    `json:"slave_state"`
 	SemiSyncState        *SemiSyncState `json:"semi_sync_state"`
+
+	ShowOnlyGTIDDiff bool
 }
 
 // Last_SQL_Errno codes, that disallow to restart replication
@@ -142,7 +144,7 @@ func (ns *NodeState) CalcGTIDDiffWithMaster() (string, error) {
 	return gtids.GTIDDiff(replicaGTID, sourceGTID)
 }
 
-func (ns *NodeState) String(showOnlyGTIDDiff bool) string {
+func (ns *NodeState) String() string {
 	ping := "ok"
 	if !ns.PingOk {
 		ping = "ERR"
@@ -157,11 +159,11 @@ func (ns *NodeState) String(showOnlyGTIDDiff bool) string {
 	if ns.SlaveState != nil {
 		repl = ns.SlaveState.ReplicationState
 
-		if showOnlyGTIDDiff {
+		if ns.ShowOnlyGTIDDiff {
 			var err error
 			gtid, err = ns.CalcGTIDDiffWithMaster()
 			if err != nil {
-				gtid = fmt.Sprintf("%s", err)
+				gtid = fmt.Sprintf("%s", err.Error())
 			}
 		} else {
 			gtid = strings.ReplaceAll(ns.SlaveState.ExecutedGtidSet, "\n", "")

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -163,7 +163,7 @@ func (ns *NodeState) String() string {
 			var err error
 			gtid, err = ns.CalcGTIDDiffWithMaster()
 			if err != nil {
-				gtid = fmt.Sprintf("%s", err.Error())
+				gtid = fmt.Sprintf("%s", err)
 			}
 		} else {
 			gtid = strings.ReplaceAll(ns.SlaveState.ExecutedGtidSet, "\n", "")

--- a/internal/app/data_test.go
+++ b/internal/app/data_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestStringerWorksOnNodeState(t *testing.T) {
 	ns := &NodeState{}
-	ns_str := fmt.Sprintf("%s", ns)
-	if ns_str != "<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???>" {
+	nsStr := fmt.Sprintf("%v", ns)
+	if nsStr != "<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???>" {
 		t.Errorf("%s", ns)
 	}
 
@@ -18,14 +18,26 @@ func TestStringerWorksOnNodeState(t *testing.T) {
 	ns.SlaveState = new(SlaveState)
 	ns.SlaveState.ExecutedGtidSet = "6DBC0B04-4B09-43DC-86CC-9AF852DED919:1-40"
 
-	ns_str = fmt.Sprintf("%s", ns)
-	if ns_str != "<ping=ERR repl= sync=??? ro=false offline=false lag=NaN du=??? cr=??? gtid=6DBC0B04-4B09-43DC-86CC-9AF852DED919:1-40>" {
+	nsStr = fmt.Sprintf("%v", ns)
+	if nsStr != "<ping=ERR repl= sync=??? ro=false offline=false lag=NaN du=??? cr=??? gtid=6DBC0B04-4B09-43DC-86CC-9AF852DED919:1-40>" {
 		t.Errorf("%s", ns)
 	}
 
 	ns.ShowOnlyGTIDDiff = true
-	ns_str = fmt.Sprintf("%s", ns)
-	if ns_str != "<ping=ERR repl= sync=??? ro=false offline=false lag=NaN du=??? cr=??? gtid=source ahead on: 6dbc0b04-4b09-43dc-86cc-9af852ded919:41-101>" {
+	nsStr = fmt.Sprintf("%v", ns)
+	if nsStr != "<ping=ERR repl= sync=??? ro=false offline=false lag=NaN du=??? cr=??? gtid=source ahead on: 6dbc0b04-4b09-43dc-86cc-9af852ded919:41-101>" {
 		t.Errorf("%s", ns)
+	}
+}
+
+func TestStringerWorksOnNodeStateMap(t *testing.T) {
+	m := make(map[string]*NodeState)
+	m["a"] = &NodeState{}
+	m["b"] = &NodeState{}
+	m["c"] = &NodeState{}
+
+	mStr := fmt.Sprintf("%v", m)
+	if mStr != "map[a:<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???> b:<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???> c:<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???>]" {
+		t.Errorf("%s", mStr)
 	}
 }

--- a/internal/app/data_test.go
+++ b/internal/app/data_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStringerWorksOnNodeState(t *testing.T) {
+	ns := &NodeState{}
+	ns_str := fmt.Sprintf("%s", ns)
+	if ns_str != "<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???>" {
+		t.Errorf("%s", ns)
+	}
+
+	ns.IsMaster = false
+	ns.MasterState = new(MasterState)
+	ns.MasterState.ExecutedGtidSet = "6DBC0B04-4B09-43DC-86CC-9AF852DED919:1-101"
+	ns.SlaveState = new(SlaveState)
+	ns.SlaveState.ExecutedGtidSet = "6DBC0B04-4B09-43DC-86CC-9AF852DED919:1-40"
+
+	ns_str = fmt.Sprintf("%s", ns)
+	if ns_str != "<ping=ERR repl= sync=??? ro=false offline=false lag=NaN du=??? cr=??? gtid=6DBC0B04-4B09-43DC-86CC-9AF852DED919:1-40>" {
+		t.Errorf("%s", ns)
+	}
+
+	ns.ShowOnlyGTIDDiff = true
+	ns_str = fmt.Sprintf("%s", ns)
+	if ns_str != "<ping=ERR repl= sync=??? ro=false offline=false lag=NaN du=??? cr=??? gtid=source ahead on: 6dbc0b04-4b09-43dc-86cc-9af852ded919:41-101>" {
+		t.Errorf("%s", ns)
+	}
+}


### PR DESCRIPTION
# Pull request description

### Describe what this PR fix
Stringer interface is broken for NodeState, so if we print map[string]*NodeState, it prints hosts with pointers.

### Please add config and mysync logs for debug purpose

Before this PR
```bash
2024-10-09T09:57:34Z INFO: cs: map[mysql1:0xc00025c2a0 mysql2:0xc0001a03f0 mysql3:0xc0000ae380]
2024-10-09T09:57:34Z INFO: dcs cs: map[mysql1:0xc000140af0 mysql2:0xc000140b60 mysql3:0xc000182310]
```

After this PR
```bash
2024-10-09T09:51:47Z INFO: cs: map[mysql1:<ping=ok repl=error sync=--- ro=true offline=false lag=NaN du=??? cr=??? gtid=> mysql2:<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???> mysql3:<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???>]
2024-10-09T09:51:47Z INFO: dcs cs: map[mysql1:<ping=ok repl=error sync=--- ro=true offline=false lag=NaN du=10.00% cr=yes gtid=> mysql2:<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???> mysql3:<ping=ERR repl=??? sync=??? ro=false offline=false lag=0.00 du=??? cr=??? gtid=???>]
```