### PR TITLE
Slightly improve logging

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2144,6 +2144,7 @@ func (app *App) getNodeState(host string) *NodeState {
 func (app *App) getLocalNodeState() *NodeState {
 	node := app.cluster.Local()
 	nodeState := app.getNodeState(node.Host())
+	nodeState.ShowOnlyGTIDDiff = app.config.ShowOnlyGTIDDiff
 
 	diskUsed, diskTotal, err := node.GetDiskUsage()
 	if err == nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2144,7 +2144,6 @@ func (app *App) getNodeState(host string) *NodeState {
 func (app *App) getLocalNodeState() *NodeState {
 	node := app.cluster.Local()
 	nodeState := app.getNodeState(node.Host())
-	nodeState.ShowOnlyGTIDDiff = app.config.ShowOnlyGTIDDiff
 
 	diskUsed, diskTotal, err := node.GetDiskUsage()
 	if err == nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2202,9 +2202,9 @@ func (app *App) getLocalDaemonState() (*DaemonState, error) {
 func (app *App) getClusterStateFromDB() map[string]*NodeState {
 	hosts := app.cluster.AllNodeHosts()
 	getter := func(host string) (*NodeState, error) {
-    if host == app.cluster.Local().Host() {
-      return app.getLocalNodeState(), nil
-    }
+		if host == app.cluster.Local().Host() {
+			return app.getLocalNodeState(), nil
+		}
 		ns := app.getNodeState(host)
 		return ns, nil
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2202,8 +2202,10 @@ func (app *App) getLocalDaemonState() (*DaemonState, error) {
 func (app *App) getClusterStateFromDB() map[string]*NodeState {
 	hosts := app.cluster.AllNodeHosts()
 	getter := func(host string) (*NodeState, error) {
+    if host == app.cluster.Local().Host() {
+      return app.getLocalNodeState(), nil
+    }
 		ns := app.getNodeState(host)
-		ns.ShowOnlyGTIDDiff = app.config.ShowOnlyGTIDDiff
 		return ns, nil
 	}
 	clusterState, _ := getNodeStatesInParallel(hosts, getter, app.logger)

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -219,6 +219,13 @@ func (ns *NodeState) String() string {
 			cr = "no"
 		}
 	}
+
+  // NodeState of replica doesn't know master gtid and always writes "master state not defined" when we calculate gtid diff
+  if ns.ShowOnlyGTIDDiff && ns.MasterState == nil {
+	  return fmt.Sprintf("<ping=%s repl=%s sync=%s ro=%v offline=%v lag=%.02f du=%s cr=%s>",
+	    ping, repl, sync, ns.IsReadOnly, ns.IsOffline, lag, du, cr)
+  }
+
 	return fmt.Sprintf("<ping=%s repl=%s sync=%s ro=%v offline=%v lag=%.02f du=%s cr=%s gtid=%s>",
 		ping, repl, sync, ns.IsReadOnly, ns.IsOffline, lag, du, cr, gtid)
 }

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -220,11 +220,11 @@ func (ns *NodeState) String() string {
 		}
 	}
 
-  // NodeState of replica doesn't know master gtid and always writes "master state not defined" when we calculate gtid diff
-  if ns.ShowOnlyGTIDDiff && ns.MasterState == nil {
-	  return fmt.Sprintf("<ping=%s repl=%s sync=%s ro=%v offline=%v lag=%.02f du=%s cr=%s>",
-	    ping, repl, sync, ns.IsReadOnly, ns.IsOffline, lag, du, cr)
-  }
+	// NodeState of replica doesn't know master gtid and always writes "master state not defined" when we calculate gtid diff
+	if ns.ShowOnlyGTIDDiff && ns.MasterState == nil {
+		return fmt.Sprintf("<ping=%s repl=%s sync=%s ro=%v offline=%v lag=%.02f du=%s cr=%s>",
+			ping, repl, sync, ns.IsReadOnly, ns.IsOffline, lag, du, cr)
+	}
 
 	return fmt.Sprintf("<ping=%s repl=%s sync=%s ro=%v offline=%v lag=%.02f du=%s cr=%s gtid=%s>",
 		ping, repl, sync, ns.IsReadOnly, ns.IsOffline, lag, du, cr, gtid)


### PR DESCRIPTION
When we use gtid diff in health check, we should ignore the gtid field on a replica, because it doesn't know the gtid of a source and always sends `master state not defined`.
We see now:
```
INFO: healthcheck: <ping=ok repl=running sync=--s ro=true offline=false lag=0.68 du=7.84% cr=no gtid=master state not defined>
```
I changed it to:
```
INFO: healthcheck: <ping=ok repl=running sync=--s ro=true offline=false lag=0.68 du=7.84% cr=no>
```

When we request data using `getClusterStateFromDB`, we know at least information about the disk usage and the daemon state on the local node and can output it to the log file.
We see now:
```
INFO: cs: map[mysql1:<ping=ok repl=master sync=--- ro=false offline=false lag=0.00 du=??? cr=??? gtid=gtid1:1-1820834>]
INFO: dcs cs: map[mysql1:<ping=ok repl=master sync=--- ro=false offline=false lag=0.00 du=17.40% cr=no gtid=gtid1:1-1820829>]
```
I changed it to:
```
INFO: cs: map[mysql1:<ping=ok repl=master sync=--- ro=false offline=false lag=0.00 du=10.00% cr=no gtid=gtid1:1-1820834>]
INFO: dcs cs: map[mysql1:<ping=ok repl=master sync=--- ro=false offline=false lag=0.00 du=17.40% cr=no gtid=gtid1:1-1820829>]
```