### PR TITLE
Fix linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,7 @@ linters:
     - bodyclose
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - funlen
     - gocritic
     - gocyclo


### PR DESCRIPTION
There is an error in the last version of golangci-lint:
```
Running [/home/runner/golangci-lint-1.64.4-linux-amd64/golangci-lint run] in [/home/runner/work/mysync/mysync] ...
  level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
  level=error msg="[linters_context] exportloopref: This linter is fully inactivated: it will not produce any reports."
  
  Error: golangci-lint exit with code 7
  Ran golangci-lint in 18477ms
  ```