### PR TITLE
Fix linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@
 
 # all available settings of specific linters
 linters-settings:
-  modules-download-mode: vendor
   dupl:
     threshold: 400
   funlen:
@@ -76,6 +75,7 @@ linters:
 run:
   go: 1.18
   timeout: 5m
+  modules-download-mode: vendor
 
 severity:
   default-severity: error

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,7 @@ linters:
     - whitespace
 
 run:
-  go: 1.18
+  go: "1.18"
   timeout: 5m
   modules-download-mode: vendor
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,7 @@ linters:
     - whitespace
 
 run:
-  go: "1.18"
+  go: "1.22"
   timeout: 5m
   modules-download-mode: mod
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,7 +75,7 @@ linters:
 run:
   go: "1.18"
   timeout: 5m
-  modules-download-mode: vendor
+  modules-download-mode: mod
 
 severity:
   default-severity: error


### PR DESCRIPTION
```
Error: Failed to run: Error: Command failed: /home/runner/golangci-lint-1.64.5-linux-amd64/golangci-lint config verify
jsonschema: "linters-settings" does not validate with "/properties/linters-settings/additionalProperties": additional properties 'modules-download-mode' not allowed
jsonschema: "run.go" does not validate with "/properties/run/properties/go/type": got number, want string
Failed executing command with error: the configuration contains invalid elements
, Error: Command failed: /home/runner/golangci-lint-1.64.5-linux-amd64/golangci-lint config verify
jsonschema: "linters-settings" does not validate with "/properties/linters-settings/additionalProperties": additional properties 'modules-download-mode' not allowed
jsonschema: "run.go" does not validate with "/properties/run/properties/go/type": got number, want string
Failed executing command with error: the configuration contains invalid elements

    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:5[38](https://github.com/yandex/mysync/actions/runs/13365576260/job/37322551991?pr=155#step:4:41):14)
    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1105:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
Error: Command failed: /home/runner/golangci-lint-1.64.5-linux-amd64/golangci-lint config verify
jsonschema: "linters-settings" does not validate with "/properties/linters-settings/additionalProperties": additional properties 'modules-download-mode' not allowed
jsonschema: "run.go" does not validate with "/properties/run/properties/go/type": got number, want string
Failed executing command with error: the configuration contains invalid elements
```
What is a nice day to change API of the linter!