### PR TITLE
Dont write general log 

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,7 @@ type Config struct {
 	ShowOnlyGTIDDiff                        bool                         `config:"show_only_gtid_diff" yaml:"show_only_gtid_diff"`
 	ManagerSwitchover                       bool                         `config:"manager_switchover" yaml:"manager_switchover"`
 	ForceSwitchover                         bool                         `config:"force_switchover" yaml:"force_switchover"` // TODO: Remove when we will be sure it's right way to do switchover
+	DSNSettings                             string                       `config:"dsn_settings" yaml:"dsn_settings"`
 }
 
 // DefaultConfig returns default configuration for MySync
@@ -190,6 +191,7 @@ func DefaultConfig() (Config, error) {
 		ShowOnlyGTIDDiff:                        false,
 		ManagerSwitchover:                       false,
 		ForceSwitchover:                         false,
+		DSNSettings:                             "?autocommit=1&sql_log_off=1",
 	}
 	return config, nil
 }

--- a/internal/mysql/node.go
+++ b/internal/mysql/node.go
@@ -79,7 +79,7 @@ func (n *Node) GetDB() (*sqlx.DB, error) {
 		addr := util.JoinHostPort(n.host, n.config.MySQL.Port)
 		dsn := fmt.Sprintf("%s:%s@tcp(%s)/mysql", n.config.MySQL.User, n.config.MySQL.Password, addr) + n.config.DSNSettings
 		if n.config.MySQL.SslCA != "" {
-			n.config.DSNSettings += "&tls=custom"
+			dsn += "&tls=custom"
 		}
 		n.db, err = sqlx.Open("mysql", dsn)
 		if err != nil {

--- a/internal/mysql/node.go
+++ b/internal/mysql/node.go
@@ -77,7 +77,7 @@ func (n *Node) GetDB() (*sqlx.DB, error) {
 	if n.done.Load() == 0 {
 		defer n.done.Store(1)
 		addr := util.JoinHostPort(n.host, n.config.MySQL.Port)
-		dsn := fmt.Sprintf("%s:%s@tcp(%s)/mysql?autocommit=1", n.config.MySQL.User, n.config.MySQL.Password, addr)
+		dsn := fmt.Sprintf("%s:%s@tcp(%s)/mysql?autocommit=1&sql_log_off=1", n.config.MySQL.User, n.config.MySQL.Password, addr)
 		if n.config.MySQL.SslCA != "" {
 			dsn += "&tls=custom"
 		}

--- a/internal/mysql/node.go
+++ b/internal/mysql/node.go
@@ -77,9 +77,9 @@ func (n *Node) GetDB() (*sqlx.DB, error) {
 	if n.done.Load() == 0 {
 		defer n.done.Store(1)
 		addr := util.JoinHostPort(n.host, n.config.MySQL.Port)
-		dsn := fmt.Sprintf("%s:%s@tcp(%s)/mysql?autocommit=1&sql_log_off=1", n.config.MySQL.User, n.config.MySQL.Password, addr)
+		dsn := fmt.Sprintf("%s:%s@tcp(%s)/mysql", n.config.MySQL.User, n.config.MySQL.Password, addr) + n.config.DSNSettings
 		if n.config.MySQL.SslCA != "" {
-			dsn += "&tls=custom"
+			n.config.DSNSettings += "&tls=custom"
 		}
 		n.db, err = sqlx.Open("mysql", dsn)
 		if err != nil {


### PR DESCRIPTION
Too many log in `query.log` when general_log=ON