### PR TITLE
Allow users to specify maintenance reason

### DIFF
--- a/cmd/mysync/maintenance.go
+++ b/cmd/mysync/maintenance.go
@@ -11,6 +11,7 @@ import (
 )
 
 var maintWait time.Duration
+var maintReason string
 
 var maintCmd = &cobra.Command{
 	Use:     "maintenance",
@@ -29,7 +30,7 @@ var maintOnCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		os.Exit(app.CliEnableMaintenance(maintWait))
+		os.Exit(app.CliEnableMaintenance(maintWait, maintReason))
 	},
 }
 
@@ -64,4 +65,6 @@ func init() {
 	maintCmd.AddCommand(maintOffCmd)
 	maintCmd.AddCommand(maintGetCmd)
 	maintCmd.PersistentFlags().DurationVarP(&maintWait, "wait", "w", 30*time.Second, "how long to wait for maintenance activation, 0s to return immediately")
+
+	maintOnCmd.Flags().StringVarP(&maintReason, "reason", "r", "", "reason for maintenance (e.g. ticket number)")
 }

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -349,7 +349,7 @@ func (app *App) CliSwitch(switchFrom, switchTo string, waitTimeout time.Duration
 }
 
 // CliEnableMaintenance enables maintenance mode
-func (app *App) CliEnableMaintenance(waitTimeout time.Duration) int {
+func (app *App) CliEnableMaintenance(waitTimeout time.Duration, reason string) int {
 	ctx := app.baseContext()
 	err := app.connectDCS()
 	if err != nil {
@@ -362,6 +362,7 @@ func (app *App) CliEnableMaintenance(waitTimeout time.Duration) int {
 	maintenance := &Maintenance{
 		InitiatedBy: app.config.Hostname,
 		InitiatedAt: time.Now(),
+		Reason:      reason,
 	}
 	err = app.dcs.Create(pathMaintenance, maintenance)
 	if err != nil && err != dcs.ErrExists {

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -348,7 +348,7 @@ type Maintenance struct {
 	InitiatedAt  time.Time `json:"initiated_at"`
 	MySyncPaused bool      `json:"mysync_paused"`
 	ShouldLeave  bool      `json:"should_leave"`
-	Reason       string    `json:"reason"`
+	Reason       string    `json:"reason,omitempty"`
 }
 
 func (m *Maintenance) String() string {

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -348,6 +348,7 @@ type Maintenance struct {
 	InitiatedAt  time.Time `json:"initiated_at"`
 	MySyncPaused bool      `json:"mysync_paused"`
 	ShouldLeave  bool      `json:"should_leave"`
+	Reason       string    `json:"reason"`
 }
 
 func (m *Maintenance) String() string {
@@ -358,5 +359,9 @@ func (m *Maintenance) String() string {
 	if m.ShouldLeave {
 		ms = "leaving"
 	}
-	return fmt.Sprintf("<%s by %s at %s>", ms, m.InitiatedBy, m.InitiatedAt)
+	reasonSuffix := ""
+	if m.Reason != "" {
+		reasonSuffix = fmt.Sprintf(" (%s)", m.Reason)
+	}
+	return fmt.Sprintf("<%s by %s at %s%s>", ms, m.InitiatedBy, m.InitiatedAt, reasonSuffix)
 }


### PR DESCRIPTION
Allow users to specify maintenance reason:

```
mysync maintenance on --reason "test maintenance"
```

and see it:
```
mysync info
...
maintenance:
  initiated_at: "2025-03-21T06:17:05.961162127Z"
  initiated_by: rc1a-mm25u5an15rj42ao.example.com
  mysync_paused: true
  reason: test maintenance
  should_leave: false
```

```
mysync info -s
...
maintenance: <ON by rc1a-mm25u5an15rj42ao.example.com at 2025-03-21
  06:17:05.961162127 +0000 UTC (test maintenance)>
```