### PR TITLE
Guess who runs 'mysync maintenance on'

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -301,7 +301,7 @@ func (app *App) CliSwitch(switchFrom, switchTo string, waitTimeout time.Duration
 
 	switchover.From = fromHost
 	switchover.To = toHost
-	switchover.InitiatedBy = app.config.Hostname
+	switchover.InitiatedBy = util.GuessWhoRunning() + "@" + app.config.Hostname
 	switchover.InitiatedAt = time.Now()
 	switchover.Cause = CauseManual
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -360,7 +360,7 @@ func (app *App) CliEnableMaintenance(waitTimeout time.Duration, reason string) i
 	app.dcs.Initialize()
 
 	maintenance := &Maintenance{
-		InitiatedBy: app.config.Hostname,
+		InitiatedBy: util.GuessWhoRunning() + "@" + app.config.Hostname,
 		InitiatedAt: time.Now(),
 		Reason:      reason,
 	}

--- a/internal/util/user.go
+++ b/internal/util/user.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"os"
+	"slices"
+
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+var notInformativeUsernames = []string{"root", "mysql"}
+
+func GuessWhoRunning() string {
+	pid := os.Getppid()
+
+	p, err := process.NewProcess(int32(pid))
+	if err != nil {
+		return ""
+	}
+
+	for i := 0; i < 50; i++ {
+		if p == nil {
+			return "unknown_dolphin"
+		}
+
+		p, err = p.Parent()
+		if err != nil {
+			return "unknown_sakila"
+		}
+
+		// Known issue: cross-compiled builds by default uses CGO_ENABLED="0" (aka static builds)
+		//     this may break user.LookupId() for LDAP/NIS users (user.UnknownUserError returned)
+		username, err := p.Username()
+		if err != nil {
+			return ""
+		}
+		if !slices.Contains(notInformativeUsernames, username) {
+			return username
+		}
+	}
+	return "unknown"
+}

--- a/tests/features/async_setting.feature
+++ b/tests/features/async_setting.feature
@@ -284,7 +284,7 @@ Feature: mysync async mode tests
           "from": "mysql1",
           "to": "",
           "cause": "manual",
-          "initiated_by": "mysql1",
+          "initiated_by": "REGEXP:.*@mysql1",
           "result": {
               "ok": true
           }

--- a/tests/features/maintenance.feature
+++ b/tests/features/maintenance.feature
@@ -214,7 +214,7 @@ Feature: maintenance mode
     And zookeeper node "/test/maintenance" should match json
       """
       {
-        "initiated_by": "mysql1"
+        "initiated_by": "REGEXP:.*@mysql1"
       }
       """
     When I run command on host "mysql1"

--- a/tests/features/switchover_from.feature
+++ b/tests/features/switchover_from.feature
@@ -29,7 +29,7 @@ Feature: manual switchover from old master
           "from": "mysql1",
           "to": "",
           "cause": "manual",
-          "initiated_by": "mysql1",
+          "initiated_by": "REGEXP:.*@mysql1",
           "result": {
               "ok": false,
               "error": "no quorum, have 0 replicas while 2 is required"
@@ -69,7 +69,7 @@ Feature: manual switchover from old master
           "from": "mysql1",
           "to": "",
           "cause": "manual",
-          "initiated_by": "mysql1",
+          "initiated_by": "REGEXP:.*@mysql1",
           "result": {
               "ok": true
           }

--- a/tests/features/switchover_from.feature
+++ b/tests/features/switchover_from.feature
@@ -69,7 +69,7 @@ Feature: manual switchover from old master
           "from": "mysql1",
           "to": "",
           "cause": "manual",
-          "initiated_by": "REGEXP:.*@mysql1",
+          "initiated_by": "mysql1",
           "result": {
               "ok": true
           }

--- a/tests/features/zk_maintenance.feature
+++ b/tests/features/zk_maintenance.feature
@@ -62,7 +62,7 @@ Feature: maintenance during dead zookeeper
     Then zookeeper node "/test/maintenance" should match json within "90" seconds
       """
       {
-        "initiated_by": "mysql1"
+        "initiated_by": "REGEXP:.*@mysql1"
       }
       """
     When I run command on host "mysql1" with timeout "30" seconds

--- a/tests/testutil/matchers/matchers.go
+++ b/tests/testutil/matchers/matchers.go
@@ -121,7 +121,15 @@ func jsonContains(a, e interface{}, path []string) []string {
 			return path
 		}
 	case reflect.String:
-		if a.(string) != e.(string) {
+		_a := a.(string)
+		_e := e.(string)
+		prefix := "REGEXP:"
+		if strings.HasPrefix(_e, prefix) {
+			eReg := regexp.MustCompile(_e[len(prefix):])
+			if !eReg.Match([]byte(_a)) {
+				return path
+			}
+		} else if _a != _e {
 			return path
 		}
 	default:

--- a/tests/testutil/matchers/matchers.go
+++ b/tests/testutil/matchers/matchers.go
@@ -126,7 +126,7 @@ func jsonContains(a, e interface{}, path []string) []string {
 		prefix := "REGEXP:"
 		if strings.HasPrefix(_e, prefix) {
 			eReg := regexp.MustCompile(_e[len(prefix):])
-			if !eReg.Match([]byte(_a)) {
+			if !eReg.MatchString(_a) {
 				return path
 			}
 		} else if _a != _e {


### PR DESCRIPTION
Guess who runs 'mysync maintenance on' and show it in mysync info:

```
mysync maintenance on --reason "test"
maintenance enabled
```

```
mysync info
...
maintenance:
  initiated_at: "2025-03-21T12:11:29.390216177Z"
  initiated_by: ostinru@rc1a-mm25u5an15rj42ao.example.com      <-- HERE!
  mysync_paused: true
  reason: test
  should_leave: false
```
