### PR TITLE
[WIP] fix IsLoadingBinlog field because flapping transactions

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -167,12 +167,13 @@ func (app *App) removeMaintenanceFile() {
 // separate goroutine performing health checks
 func (app *App) healthChecker(ctx context.Context) {
 	ticker := time.NewTicker(app.config.HealthCheckInterval)
-	var oldBinLogPos string
+	var logFile string
+	var maxLogPos int64
 	for {
 		select {
 		case <-ticker.C:
 			hc := app.getLocalNodeState()
-			oldBinLogPos = hc.UpdateBinlogStatus(oldBinLogPos)
+			logFile, maxLogPos = hc.UpdateBinlogStatus(logFile, maxLogPos)
 			app.logger.Infof("healthcheck: %v", hc)
 			err := app.dcs.SetEphemeral(dcs.JoinPath(pathHealthPrefix, app.config.Hostname), hc)
 			if err != nil {

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -156,11 +156,11 @@ func (ns *NodeState) UpdateBinlogStatus(oldLogFile string, maxLogPos int64) (str
 	newLogFile := ns.SlaveState.MasterLogFile
 	newLogPos := ns.SlaveState.MasterLogPos
 
-  // IsLoadingBinlog is reset to false when starting to load a new binlog file.
-  // Example:
-  //   - Current position: MasterLogFile = "mysql-bin.000016", MasterLogPos = 784
-  //   - When switching to "mysql-bin.000017", IsLoadingBinlog becomes false
-  //     until the new file begins processing.
+	// IsLoadingBinlog is reset to false when starting to load a new binlog file.
+	// Example:
+	//   - Current position: MasterLogFile = "mysql-bin.000016", MasterLogPos = 784
+	//   - When switching to "mysql-bin.000017", IsLoadingBinlog becomes false
+	//     until the new file begins processing.
 	if newLogFile != oldLogFile {
 		ns.IsLoadingBinlog = false
 		return newLogFile, newLogPos

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -156,7 +156,11 @@ func (ns *NodeState) UpdateBinlogStatus(oldLogFile string, maxLogPos int64) (str
 	newLogFile := ns.SlaveState.MasterLogFile
 	newLogPos := ns.SlaveState.MasterLogPos
 
-	// need to reset maxBinlogPos after master switchover
+  // IsLoadingBinlog is reset to false when starting to load a new binlog file.
+  // Example:
+  //   - Current position: MasterLogFile = "mysql-bin.000016", MasterLogPos = 784
+  //   - When switching to "mysql-bin.000017", IsLoadingBinlog becomes false
+  //     until the new file begins processing.
 	if newLogFile != oldLogFile {
 		ns.IsLoadingBinlog = false
 		return newLogFile, newLogPos

--- a/internal/app/data_test.go
+++ b/internal/app/data_test.go
@@ -63,21 +63,53 @@ func newMockNodeState() *NodeState {
 }
 
 func TestUpdateBinlogWithChanges(t *testing.T) {
-	oldBinlogPostion := "test_master_log_file0000000000000000001"
+	oldLogFile := "test_master_log_file"
+	maxLogPos := int64(1)
+
 	ns := newMockNodeState()
 
-	newBinlogPos := ns.UpdateBinlogStatus(oldBinlogPostion)
+	oldLogFile, maxLogPos = ns.UpdateBinlogStatus(oldLogFile, maxLogPos)
 
-	require.Equal(t, "test_master_log_file0000000000000000002", newBinlogPos)
+	require.Equal(t, "test_master_log_file", oldLogFile)
+	require.Equal(t, int64(2), maxLogPos)
 	require.Equal(t, true, ns.IsLoadingBinlog)
 }
 
 func TestUpdateBinlogWithoutChanges(t *testing.T) {
-	oldBinlogPostion := "test_master_log_file0000000000000000002"
+	oldLogFile := "test_master_log_file"
+	maxLogPos := int64(2)
+
 	ns := newMockNodeState()
 
-	newBinlogPos := ns.UpdateBinlogStatus(oldBinlogPostion)
+	oldLogFile, maxLogPos = ns.UpdateBinlogStatus(oldLogFile, maxLogPos)
 
-	require.Equal(t, "test_master_log_file0000000000000000002", newBinlogPos)
+	require.Equal(t, "test_master_log_file", oldLogFile)
+	require.Equal(t, int64(2), maxLogPos)
+	require.Equal(t, false, ns.IsLoadingBinlog)
+}
+
+func TestUpdateBinlogAfterReloading(t *testing.T) {
+	oldLogFile := "test_master_log_file"
+	maxLogPos := int64(5)
+
+	ns := newMockNodeState()
+
+	oldLogFile, maxLogPos = ns.UpdateBinlogStatus(oldLogFile, maxLogPos)
+
+	require.Equal(t, "test_master_log_file", oldLogFile)
+	require.Equal(t, int64(5), maxLogPos)
+	require.Equal(t, false, ns.IsLoadingBinlog)
+}
+
+func TestUpdateBinlogAfterMasterSwitch(t *testing.T) {
+	oldLogFile := "old_log_file"
+	maxLogPos := int64(5)
+
+	ns := newMockNodeState()
+
+	oldLogFile, maxLogPos = ns.UpdateBinlogStatus(oldLogFile, maxLogPos)
+
+	require.Equal(t, "test_master_log_file", oldLogFile)
+	require.Equal(t, int64(2), maxLogPos)
 	require.Equal(t, false, ns.IsLoadingBinlog)
 }


### PR DESCRIPTION
When downloading the binlog, issues may occur due to various reasons, prompting the binlog to be re-loaded. To ensure such cases are handled by duty, the isLoadingBinlog flag must be set to false when the replica is re-loading the binlog.