### PR TITLE
Add turbo mode to CLI

### DIFF
--- a/cmd/mysync/maintenance.go
+++ b/cmd/mysync/maintenance.go
@@ -17,8 +17,8 @@ var maintCmd = &cobra.Command{
 	Use:     "maintenance",
 	Aliases: []string{"maint", "mnt"},
 	Short:   "Enables or disables maintenance mode",
-	Long: ("When maintenance is enabled MySync manager will not perform any actions.\n" +
-		"When maintenance is disabled MySync will analyze cluster state and remember it as correct."),
+	Long: ("When maintenance is enabled, MySync manager will not perform any actions.\n" +
+		"When maintenance is disabled, MySync will analyze cluster state and remember it as correct."),
 }
 
 var maintOnCmd = &cobra.Command{

--- a/cmd/mysync/optimize.go
+++ b/cmd/mysync/optimize.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yandex/mysync/internal/app"
+)
+
+var optimizeCmd = &cobra.Command{
+	Use:     "optimize",
+	Aliases: []string{"turbo"},
+	Short:   "Enables or disables optimization mode",
+	Long: ("When optimization mode is enabled, MySync turns on potentially dangerous options to reduce disk usage.\n" +
+		"When optimization mode is disabled, MySync restores safe defaults, and the host operates in normal mode.\n" +
+		"Optimization works only on replica hosts and cannot be enabled on the master host."),
+}
+
+var optimizeOnCmd = &cobra.Command{
+	Use:     "on",
+	Aliases: []string{"enable"},
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := app.NewApp(configFile, logLevel, true)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		os.Exit(app.CliEnableOptimization())
+	},
+}
+
+var optimizeOffCmd = &cobra.Command{
+	Use:     "off",
+	Aliases: []string{"disable"},
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := app.NewApp(configFile, logLevel, true)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		os.Exit(app.CliDisableOptimization())
+	},
+}
+
+var optimizeGetCmd = &cobra.Command{
+	Use: "get",
+	Run: func(cmd *cobra.Command, args []string) {
+		app, err := app.NewApp(configFile, logLevel, true)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		os.Exit(app.CliGetOptimization())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(optimizeCmd)
+	optimizeCmd.AddCommand(optimizeOnCmd)
+	optimizeCmd.AddCommand(optimizeOffCmd)
+	optimizeCmd.AddCommand(optimizeGetCmd)
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1188,8 +1188,8 @@ func (app *App) updateActiveNodes(clusterState, clusterStateDcs map[string]*Node
 			return err
 		}
 
-    node := app.cluster.Get(host)
-    err = node.OptimizeReplication()
+		node := app.cluster.Get(host)
+		err = node.OptimizeReplication()
 		if err != nil {
 			app.logger.Warnf("failed to enable optimization on slave %s: %v", host, err)
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1187,6 +1187,12 @@ func (app *App) updateActiveNodes(clusterState, clusterStateDcs map[string]*Node
 		if err != nil {
 			return err
 		}
+
+    node := app.cluster.Get(host)
+    err = node.OptimizeReplication()
+		if err != nil {
+			app.logger.Warnf("failed to enable optimization on slave %s: %v", host, err)
+		}
 	}
 
 	// enlarge HA-group, if needed (and if possible)
@@ -1590,6 +1596,15 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 	}
 
 	return nil
+}
+
+func (app *App) SetDefaultReplicationSettingsForNode(node *mysql.Node) error {
+	masterFqdn, err := app.GetMasterHostFromDcs()
+	if err != nil {
+		return err
+	}
+	master := app.cluster.Get(masterFqdn)
+	return node.SetDefaultReplicationSettings(master)
 }
 
 func (app *App) getCurrentMaster(clusterState map[string]*NodeState) (string, error) {

--- a/internal/app/cli_optimize.go
+++ b/internal/app/cli_optimize.go
@@ -113,8 +113,8 @@ type HostOptimizationStatus string
 
 const (
 	OptimizationRunning        HostOptimizationStatus = "optimization is running"
-	Optimizable                                       = "can be optimized"
-	UnoptimizableConfiguration                        = "configuration of the cluster is already optimized"
-	HostRoleMaster                                    = "host is master"
-	Unknown                                           = "unknown"
+	Optimizable                HostOptimizationStatus = "can be optimized"
+	UnoptimizableConfiguration HostOptimizationStatus = "configuration of the cluster is already optimized"
+	HostRoleMaster             HostOptimizationStatus = "host is master"
+	Unknown                    HostOptimizationStatus = "unknown"
 )

--- a/internal/app/cli_optimize.go
+++ b/internal/app/cli_optimize.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/yandex/mysync/internal/mysql"
+)
+
+// CliEnableOptimization enables optimization mode
+func (app *App) CliEnableOptimization() int {
+	cancel, err := app.cliInitApp()
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return 1
+	}
+	defer cancel()
+
+	node := app.cluster.Local()
+	status, err := app.cliGetHostOptimizationStatus(node)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return 1
+	}
+
+	if status == Optimizable {
+		err = node.OptimizeReplication()
+		if err != nil {
+			fmt.Printf("%s\n", err)
+			return 1
+		}
+		fmt.Println("The host optimization has been started.")
+		return 0
+	}
+
+	fmt.Printf("Can't optimize host in status '%s'\n", status)
+	return 1
+}
+
+// CliDisableOptimization disables optimization mode
+func (app *App) CliDisableOptimization() int {
+	cancel, err := app.cliInitApp()
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return 1
+	}
+	defer cancel()
+
+	node := app.cluster.Local()
+	err = app.SetDefaultReplicationSettingsForNode(node)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return 1
+	}
+	return 0
+}
+
+// CliGetOptimization gets optimization mode
+func (app *App) CliGetOptimization() int {
+	cancel, err := app.cliInitApp()
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return 1
+	}
+	defer cancel()
+
+	node := app.cluster.Local()
+	status, err := app.cliGetHostOptimizationStatus(node)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return 1
+	}
+
+	fmt.Printf("The host is in status '%s'\n", status)
+
+	return 0
+}
+
+func (app *App) cliGetHostOptimizationStatus(localNode *mysql.Node) (HostOptimizationStatus, error) {
+	status, err := localNode.GetReplicaStatus()
+	if err != nil {
+		return Unknown, err
+	}
+	if status == nil {
+		return HostRoleMaster, nil
+	}
+
+	replicationSettings, err := localNode.GetReplicationSettings()
+	if err != nil {
+		return Unknown, nil
+	}
+	if replicationSettings.CanBeOptimized() {
+		return Optimizable, nil
+	}
+
+	masterFqdn, err := app.GetMasterHostFromDcs()
+	if err != nil {
+		return Unknown, nil
+	}
+
+	master := app.cluster.Get(masterFqdn)
+	masterReplicationSettings, err := master.GetReplicationSettings()
+	if err != nil {
+		return Unknown, nil
+	}
+
+	if masterReplicationSettings.Equal(&replicationSettings) {
+		return UnoptimizableConfiguration, nil
+	}
+	return OptimizationRunning, nil
+}
+
+type HostOptimizationStatus string
+
+const (
+	OptimizationRunning        HostOptimizationStatus = "optimization is running"
+	Optimizable                                       = "can be optimized"
+	UnoptimizableConfiguration                        = "configuration of the cluster is already optimized"
+	HostRoleMaster                                    = "host is master"
+	Unknown                                           = "unknown"
+)

--- a/internal/app/cli_util.go
+++ b/internal/app/cli_util.go
@@ -1,5 +1,7 @@
 package app
 
+// cliInitApp consolidates initialization logic for CLI commands to reduce boilerplate code.
+// The returned cleanup function closes the dcs and cluster connections to prevent leaks.
 func (app *App) cliInitApp() (func(), error) {
 	err := app.connectDCS()
 	if err != nil {
@@ -7,12 +9,6 @@ func (app *App) cliInitApp() (func(), error) {
 	}
 
 	app.dcs.Initialize()
-	err = app.newDBCluster()
-	if err != nil {
-		app.dcs.Close()
-		return nil, err
-	}
-
 	err = app.newDBCluster()
 	if err != nil {
 		app.dcs.Close()

--- a/internal/app/cli_util.go
+++ b/internal/app/cli_util.go
@@ -1,0 +1,33 @@
+package app
+
+func (app *App) cliInitApp() (func(), error) {
+	err := app.connectDCS()
+	if err != nil {
+		return nil, err
+	}
+
+	app.dcs.Initialize()
+	err = app.newDBCluster()
+	if err != nil {
+		app.dcs.Close()
+		return nil, err
+	}
+
+	err = app.newDBCluster()
+	if err != nil {
+		app.dcs.Close()
+		return nil, err
+	}
+
+	err = app.cluster.UpdateHostsInfo()
+	if err != nil {
+		app.dcs.Close()
+		app.cluster.Close()
+		return nil, err
+	}
+
+	return func() {
+		app.dcs.Close()
+		app.cluster.Close()
+	}, nil
+}

--- a/internal/mysql/cluster.go
+++ b/internal/mysql/cluster.go
@@ -152,7 +152,7 @@ func (c *Cluster) Get(host string) *Node {
 	return c.cascadeNodes[host]
 }
 
-// Local returns MySQL Node running on the same not as current mysync process
+// Local returns a MySQL Node running on the same host as the current mysync process
 func (c *Cluster) Local() *Node {
 	return c.local
 }

--- a/internal/mysql/node.go
+++ b/internal/mysql/node.go
@@ -1082,9 +1082,9 @@ type ReplicationSettings struct {
 	SyncBinlog                int `db:"SyncBinlog"`
 }
 
-func (lhs *ReplicationSettings) Equal(rhs *ReplicationSettings) bool {
-	if lhs.SyncBinlog == rhs.SyncBinlog &&
-		lhs.InnodbFlushLogAtTrxCommit == rhs.InnodbFlushLogAtTrxCommit {
+func (rs *ReplicationSettings) Equal(anotherRs *ReplicationSettings) bool {
+	if rs.SyncBinlog == anotherRs.SyncBinlog &&
+		rs.InnodbFlushLogAtTrxCommit == anotherRs.InnodbFlushLogAtTrxCommit {
 		return true
 	}
 	return false

--- a/internal/mysql/node.go
+++ b/internal/mysql/node.go
@@ -51,6 +51,7 @@ var (
 const (
 	optimalSyncBinlogValue                = 1000
 	optimalInnodbFlushLogAtTrxCommitValue = 2
+	defaultInnodbFlushLogAtTrxCommitValue = 1
 )
 
 // NewNode returns new Node
@@ -1079,6 +1080,35 @@ func (n *Node) OptimizeReplication() error {
 type ReplicationSettings struct {
 	InnodbFlushLogAtTrxCommit int `db:"InnodbFlushLogAtTrxCommit"`
 	SyncBinlog                int `db:"SyncBinlog"`
+}
+
+func (lhs *ReplicationSettings) Equal(rhs *ReplicationSettings) bool {
+	if lhs.SyncBinlog == rhs.SyncBinlog &&
+		lhs.InnodbFlushLogAtTrxCommit == rhs.InnodbFlushLogAtTrxCommit {
+		return true
+	}
+	return false
+}
+
+// There may be the cases where the user specified master settings that are higher than our "optimal" ones or equal to them.
+func (rs *ReplicationSettings) CanBeOptimized() bool {
+	if rs.SyncBinlog >= optimalSyncBinlogValue {
+		return false
+	}
+
+	if rs.InnodbFlushLogAtTrxCommit != optimalInnodbFlushLogAtTrxCommitValue &&
+		rs.InnodbFlushLogAtTrxCommit != defaultInnodbFlushLogAtTrxCommitValue {
+		return false
+	}
+
+	return true
+}
+
+// GetReplicationSettings retrieves replication settings from the host
+func (n *Node) GetReplicationSettings() (ReplicationSettings, error) {
+	var rs ReplicationSettings
+	err := n.queryRow(queryGetReplicationSettings, nil, &rs)
+	return rs, err
 }
 
 // SetDefaultReplicationSettings sets default values for replication based on the value on the master

--- a/internal/mysql/node.go
+++ b/internal/mysql/node.go
@@ -1090,7 +1090,7 @@ func (lhs *ReplicationSettings) Equal(rhs *ReplicationSettings) bool {
 	return false
 }
 
-// There may be the cases where the user specified master settings that are higher than our "optimal" ones or equal to them.
+// There may be cases where the user specified master settings that are higher than our "optimal" ones or equal to them.
 func (rs *ReplicationSettings) CanBeOptimized() bool {
 	if rs.SyncBinlog >= optimalSyncBinlogValue {
 		return false

--- a/internal/mysql/queries.go
+++ b/internal/mysql/queries.go
@@ -127,7 +127,7 @@ var DefaultQueries = map[string]string{
 						FOR CHANNEL :channel`,
 	queryIgnoreDB:                     `CHANGE REPLICATION FILTER REPLICATE_IGNORE_DB = (:ignoreList) FOR CHANNEl :channel`,
 	querySetInnodbFlushLogAtTrxCommit: `SET GLOBAL innodb_flush_log_at_trx_commit = :level`,
-	queryGetReplicationSettings:       `SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog`,
+	queryGetReplicationSettings:       `SELECT @@GLOBAL.innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@GLOBAL.sync_binlog as SyncBinlog`,
 	querySetSyncBinlog:                `SET GLOBAL sync_binlog = :sync_binlog`,
 	queryGetReplMonTS:                 `SELECT UNIX_TIMESTAMP(ts) AS ts FROM :replMonSchemeName.:replMonTable`,
 	queryCalcReplMonTSDelay:           `SELECT FLOOR(CAST(:ts AS DECIMAL(20,3)) - UNIX_TIMESTAMP(ts)) AS delay FROM :replMonSchemeName.:replMonTable`,

--- a/tests/features/CLI.feature
+++ b/tests/features/CLI.feature
@@ -138,7 +138,7 @@ Feature: CLI
 
         When I run SQL on mysql host "mysql2"
         """
-        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        SELECT @@GLOBAL.innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@GLOBAL.sync_binlog as SyncBinlog
         """
         Then SQL result should match json
         """
@@ -161,7 +161,7 @@ Feature: CLI
         Then command return code should be "0"
         When I run SQL on mysql host "mysql2"
         """
-        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        SELECT @@GLOBAL.innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@GLOBAL.sync_binlog as SyncBinlog
         """
         Then SQL result should match json
         """
@@ -184,7 +184,7 @@ Feature: CLI
         Then command return code should be "0"
         When I run SQL on mysql host "mysql2"
         """
-        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        SELECT @@GLOBAL.innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@GLOBAL.sync_binlog as SyncBinlog
         """
         Then SQL result should match json
         """
@@ -230,7 +230,7 @@ Feature: CLI
         Then command return code should be "0"
         When I run SQL on mysql host "mysql2"
         """
-        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        SELECT @@GLOBAL.innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@GLOBAL.sync_binlog as SyncBinlog
         """
         Then SQL result should match json
         """
@@ -243,7 +243,7 @@ Feature: CLI
         Then command return code should be "0"
         When I run SQL on mysql host "mysql2"
         """
-        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        SELECT @@GLOBAL.innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@GLOBAL.sync_binlog as SyncBinlog
         """
         Then SQL result should match json
         """

--- a/tests/features/CLI.feature
+++ b/tests/features/CLI.feature
@@ -136,7 +136,6 @@ Feature: CLI
         And mysql host "mysql2" should be replica of "mysql1"
         And mysql host "mysql3" should be replica of "mysql1"
 
-        # Try to optimize host with default settings
         When I run SQL on mysql host "mysql2"
         """
         SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
@@ -178,7 +177,6 @@ Feature: CLI
         The host is in status 'optimization is running'
         """
 
-        # Try to stop optimization on host with default settings
         When I run command on host "mysql2"
         """
         mysync turbo off
@@ -202,7 +200,12 @@ Feature: CLI
         The host is in status 'can be optimized'
         """
 
-        # Host optimization with non-default option which less than MySync "optimal" ones
+    Scenario: CLI turbo mode works properly with non-default replication options
+        Given cluster is up and running
+        Then mysql host "mysql1" should be master
+        And mysql host "mysql2" should be replica of "mysql1"
+        And mysql host "mysql3" should be replica of "mysql1"
+
         When I run SQL on mysql host "mysql1"
         """
         SET GLOBAL innodb_flush_log_at_trx_commit = 2; SET GLOBAL sync_binlog = 999;
@@ -247,7 +250,12 @@ Feature: CLI
         [{"InnodbFlushLogAtTrxCommit":2,"SyncBinlog":999}]
         """
 
-        # Host optimization with non-default option which more than MySync "optimal" ones
+    Scenario: CLI turbo mode works properly with non-default replication options which are more than MySync optimal ones
+        Given cluster is up and running
+        Then mysql host "mysql1" should be master
+        And mysql host "mysql2" should be replica of "mysql1"
+        And mysql host "mysql3" should be replica of "mysql1"
+
         When I run SQL on mysql host "mysql1"
         """
         SET GLOBAL innodb_flush_log_at_trx_commit = 2; SET GLOBAL sync_binlog = 1001;
@@ -275,7 +283,6 @@ Feature: CLI
         Can't optimize host in status 'configuration of the cluster is already optimized'
         """
 
-        # Host optimization with non-default option 'innodb_flush_log_at_trx_commit'
         When I run SQL on mysql host "mysql1"
         """
         SET GLOBAL innodb_flush_log_at_trx_commit = 0; SET GLOBAL sync_binlog = 3;
@@ -309,7 +316,12 @@ Feature: CLI
         Can't optimize host in status 'host is master'
         """
 
-        # Master host can't be optimizated
+    Scenario: CLI turbo mode works properly on master host
+        Given cluster is up and running
+        Then mysql host "mysql1" should be master
+        And mysql host "mysql2" should be replica of "mysql1"
+        And mysql host "mysql3" should be replica of "mysql1"
+
         When I run command on host "mysql1"
         """
         mysync turbo on

--- a/tests/features/CLI.feature
+++ b/tests/features/CLI.feature
@@ -129,3 +129,193 @@ Feature: CLI
         """
         Then command return code should be "0"
         Then zookeeper node "/test/cascade_nodes/mysql2" should not exist within "5" seconds
+
+    Scenario: CLI turbo mode works properly
+        Given cluster is up and running
+        Then mysql host "mysql1" should be master
+        And mysql host "mysql2" should be replica of "mysql1"
+        And mysql host "mysql3" should be replica of "mysql1"
+
+        # Try to optimize host with default settings
+        When I run SQL on mysql host "mysql2"
+        """
+        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        """
+        Then SQL result should match json
+        """
+        [{"InnodbFlushLogAtTrxCommit":1,"SyncBinlog":1}]
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo get
+        """
+        Then command return code should be "0"
+        And command output should match regexp
+        """
+        The host is in status 'can be optimized'
+        """
+
+        When I run command on host "mysql2"
+        """
+        mysync turbo on
+        """
+        Then command return code should be "0"
+        When I run SQL on mysql host "mysql2"
+        """
+        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        """
+        Then SQL result should match json
+        """
+        [{"InnodbFlushLogAtTrxCommit":2,"SyncBinlog":1000}]
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo get
+        """
+        Then command return code should be "0"
+        And command output should match regexp
+        """
+        The host is in status 'optimization is running'
+        """
+
+        # Try to stop optimization on host with default settings
+        When I run command on host "mysql2"
+        """
+        mysync turbo off
+        """
+        Then command return code should be "0"
+        When I run SQL on mysql host "mysql2"
+        """
+        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        """
+        Then SQL result should match json
+        """
+        [{"InnodbFlushLogAtTrxCommit":1,"SyncBinlog":1}]
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo get
+        """
+        Then command return code should be "0"
+        And command output should match regexp
+        """
+        The host is in status 'can be optimized'
+        """
+
+        # Host optimization with non-default option which less than MySync "optimal" ones
+        When I run SQL on mysql host "mysql1"
+        """
+        SET GLOBAL innodb_flush_log_at_trx_commit = 2; SET GLOBAL sync_binlog = 999;
+        """
+        When I run command on host "mysql2"
+        """
+        SET GLOBAL innodb_flush_log_at_trx_commit = 2; SET GLOBAL sync_binlog = 999;
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo get
+        """
+        Then command return code should be "0"
+        And command output should match regexp
+        """
+        The host is in status 'can be optimized'
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo on
+        """
+        Then command return code should be "0"
+        When I run SQL on mysql host "mysql2"
+        """
+        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        """
+        Then SQL result should match json
+        """
+        [{"InnodbFlushLogAtTrxCommit":2,"SyncBinlog":1000}]
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo off
+        """
+        Then command return code should be "0"
+        When I run SQL on mysql host "mysql2"
+        """
+        SELECT @@innodb_flush_log_at_trx_commit as InnodbFlushLogAtTrxCommit, @@sync_binlog as SyncBinlog
+        """
+        Then SQL result should match json
+        """
+        [{"InnodbFlushLogAtTrxCommit":2,"SyncBinlog":999}]
+        """
+
+        # Host optimization with non-default option which more than MySync "optimal" ones
+        When I run SQL on mysql host "mysql1"
+        """
+        SET GLOBAL innodb_flush_log_at_trx_commit = 2; SET GLOBAL sync_binlog = 1001;
+        """
+        When I run SQL on mysql host "mysql2"
+        """
+        SET GLOBAL innodb_flush_log_at_trx_commit = 2; SET GLOBAL sync_binlog = 1001;
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo get
+        """
+        Then command return code should be "0"
+        And command output should match regexp
+        """
+        The host is in status 'configuration of the cluster is already optimized'
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo on
+        """
+        Then command return code should be "1"
+        And command output should match regexp
+        """
+        Can't optimize host in status 'configuration of the cluster is already optimized'
+        """
+
+        # Host optimization with non-default option 'innodb_flush_log_at_trx_commit'
+        When I run SQL on mysql host "mysql1"
+        """
+        SET GLOBAL innodb_flush_log_at_trx_commit = 0; SET GLOBAL sync_binlog = 3;
+        """
+        When I run SQL on mysql host "mysql2"
+        """
+        SET GLOBAL innodb_flush_log_at_trx_commit = 0; SET GLOBAL sync_binlog = 3;
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo get
+        """
+        Then command return code should be "0"
+        And command output should match regexp
+        """
+        The host is in status 'configuration of the cluster is already optimized'
+        """
+        When I run command on host "mysql2"
+        """
+        mysync turbo on
+        """
+        Then command return code should be "1"
+
+        When I run command on host "mysql1"
+        """
+        mysync turbo on
+        """
+        Then command return code should be "1"
+        And command output should match regexp
+        """
+        Can't optimize host in status 'host is master'
+        """
+
+        # Master host can't be optimizated
+        When I run command on host "mysql1"
+        """
+        mysync turbo on
+        """
+        Then command return code should be "1"
+        And command output should match regexp
+        """
+        Can't optimize host in status 'host is master'
+        """

--- a/tests/features/CLI.feature
+++ b/tests/features/CLI.feature
@@ -250,7 +250,7 @@ Feature: CLI
         [{"InnodbFlushLogAtTrxCommit":2,"SyncBinlog":999}]
         """
 
-    Scenario: CLI turbo mode works properly with non-default replication options which are more than MySync optimal ones
+    Scenario: CLI turbo mode works properly with non-default replication options, which are more than MySync optimal ones
         Given cluster is up and running
         Then mysql host "mysql1" should be master
         And mysql host "mysql2" should be replica of "mysql1"


### PR DESCRIPTION
# Pull request description

These changes introduce an optional 'turbo' mode to accelerate replication convergence. Enabling this mode for lagging replicas reduces their disk pressure and speeds up catch-up time with the primary node. However, this mode carries a risk of data loss and should be used with caution.

Additionally, the changes include optimization replicas with excessive lag that are no longer participating in the semi-sync process.