### PR TITLE
Do not do switchover in unstable network

### DIFF
--- a/cmd/mysync/switch.go
+++ b/cmd/mysync/switch.go
@@ -13,6 +13,7 @@ import (
 var switchTo string
 var switchFrom string
 var switchWait time.Duration
+var failover bool
 
 var switchCmd = &cobra.Command{
 	Use:   "switch",
@@ -24,7 +25,7 @@ var switchCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		os.Exit(app.CliSwitch(switchFrom, switchTo, switchWait))
+		os.Exit(app.CliSwitch(switchFrom, switchTo, switchWait, failover))
 	},
 }
 
@@ -33,4 +34,5 @@ func init() {
 	switchCmd.Flags().StringVar(&switchFrom, "from", "", "switch master from specific (or current master if empty) host")
 	switchCmd.Flags().StringVar(&switchTo, "to", "", "switch master to specific (or most up-to-date if empty) host")
 	switchCmd.Flags().DurationVarP(&switchWait, "wait", "w", 5*time.Minute, "how long wait for switchover to complete, 0s to return immediately")
+	switchCmd.Flags().BoolVar(&failover, "failover", false, "ignore the master's liveness probe during switchover")
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -785,13 +785,13 @@ func (app *App) stateManager() appState {
 func (app *App) checkMasterVisible(clusterStateFromDB, clusterStateDcs map[string]*NodeState) (bool, error) {
 	masterHost, err := app.getMasterHost(clusterStateDcs)
 	if err != nil {
-		app.logger.Errorf("checkMasterVisible: can`t get muster host, error: %s", err)
+		app.logger.Errorf("checkMasterVisible: can't get master host, error: %s", err)
 		return false, err
 	}
 	state, ok := clusterStateFromDB[masterHost]
 	app.logger.Debugf("master(%s) state pingOk == %s", masterHost, state)
 	if ok && state.PingOk {
-		app.logger.Debug("Master is visible by manager, than we don`t need manager`s switchover")
+		app.logger.Debug("Master is visible by manager, then we don't need switchover")
 		return true, nil
 	}
 
@@ -1342,7 +1342,7 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 	if dubious := getDubiousHAHosts(clusterState); len(dubious) > 0 {
 		return fmt.Errorf("switchover: failed to ping hosts: %v with dubious errors", dubious)
 	}
-  app.logger.Infof("switchover: %+v", switchover.MasterTransition)
+	app.logger.Infof("switchover: %+v", switchover.MasterTransition)
 
 	activeNodesWithOldMaster := activeNodes
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1342,6 +1342,7 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 	if dubious := getDubiousHAHosts(clusterState); len(dubious) > 0 {
 		return fmt.Errorf("switchover: failed to ping hosts: %v with dubious errors", dubious)
 	}
+  app.logger.Infof("switchover: %+v", switchover.MasterTransition)
 
 	activeNodesWithOldMaster := activeNodes
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1428,19 +1428,7 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 		}
 		app.logger.Infof("switchover: host %s replication IO thread stopped", host)
 		return nil
-	}, activeNodes)
-
-	// if master was not among activeNodes - there will be no key in errs
-	if err, ok := errs2[oldMaster]; ok && err != nil && switchover.MasterTransition == SwitchoverTransition {
-		err = fmt.Errorf("switchover: failed to set old master %s read-only %s", oldMaster, err)
-		app.logger.Info(err.Error())
-		switchErr := app.FinishSwitchover(switchover, err)
-		if switchErr != nil {
-			return fmt.Errorf("switchover: failed to reject switchover %s", switchErr)
-		}
-		app.logger.Info("switchover: rejected")
-		return err
-	}
+	}, filterOut(activeNodes, []string{oldMaster}))
 
 	// count successfully stopped active nodes and check one more time that we have a quorum
 	var frozenActiveNodes []string

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -791,7 +791,7 @@ func (app *App) checkMasterVisible(clusterStateFromDB, clusterStateDcs map[strin
 	state, ok := clusterStateFromDB[masterHost]
 	app.logger.Debugf("master(%s) state pingOk == %s", masterHost, state)
 	if ok && state.PingOk {
-		app.logger.Debug("Master is visible by manager, then we don't need switchover")
+		app.logger.Debug("Master is visible by manager; then, we don't need switchover")
 		return true, nil
 	}
 

--- a/internal/app/app_dcs.go
+++ b/internal/app/app_dcs.go
@@ -171,6 +171,7 @@ func (app *App) StartSwitchover(switchover *Switchover) error {
 	app.logger.Infof("switchover: %s => %s starting...", switchover.From, switchover.To)
 	switchover.StartedAt = time.Now()
 	switchover.StartedBy = app.config.Hostname
+	switchover.MasterTransition = SwitchoverTransition
 	return app.dcs.Set(pathCurrentSwitch, switchover)
 }
 
@@ -198,6 +199,7 @@ func (app *App) IssueFailover(master string) error {
 	switchover.InitiatedBy = app.config.Hostname
 	switchover.InitiatedAt = time.Now()
 	switchover.Cause = CauseAuto
+	switchover.MasterTransition = FailoverTransition
 	return app.dcs.Create(pathCurrentSwitch, switchover)
 }
 

--- a/internal/app/app_dcs.go
+++ b/internal/app/app_dcs.go
@@ -171,7 +171,6 @@ func (app *App) StartSwitchover(switchover *Switchover) error {
 	app.logger.Infof("switchover: %s => %s starting...", switchover.From, switchover.To)
 	switchover.StartedAt = time.Now()
 	switchover.StartedBy = app.config.Hostname
-	switchover.MasterTransition = SwitchoverTransition
 	return app.dcs.Set(pathCurrentSwitch, switchover)
 }
 

--- a/internal/app/cli_switch.go
+++ b/internal/app/cli_switch.go
@@ -15,7 +15,7 @@ import (
 
 // CliSwitch performs manual switch-over of the master node
 // nolint: gocyclo, funlen
-func (app *App) CliSwitch(switchFrom, switchTo string, waitTimeout time.Duration) int {
+func (app *App) CliSwitch(switchFrom, switchTo string, waitTimeout time.Duration, failover bool) int {
 	ctx := app.baseContext()
 	if switchFrom == "" && switchTo == "" {
 		app.logger.Errorf("Either --from or --to should be set")
@@ -129,6 +129,11 @@ func (app *App) CliSwitch(switchFrom, switchTo string, waitTimeout time.Duration
 	switchover.InitiatedBy = util.GuessWhoRunning() + "@" + app.config.Hostname
 	switchover.InitiatedAt = time.Now()
 	switchover.Cause = CauseManual
+	if failover {
+		switchover.MasterTransition = FailoverTransition
+	} else {
+		switchover.MasterTransition = SwitchoverTransition
+	}
 
 	err = app.dcs.Create(pathCurrentSwitch, switchover)
 	if err == dcs.ErrExists {

--- a/internal/app/data.go
+++ b/internal/app/data.go
@@ -314,17 +314,25 @@ const (
 	CauseAuto = "auto"
 )
 
+type MasterTransition string
+
+const (
+	FailoverTransition   MasterTransition = "failover"
+	SwitchoverTransition MasterTransition = "switchover"
+)
+
 // Switchover contains info about currently running or scheduled switchover/failover process
 type Switchover struct {
-	From        string            `json:"from"`
-	To          string            `json:"to"`
-	Cause       string            `json:"cause"`
-	InitiatedBy string            `json:"initiated_by"`
-	InitiatedAt time.Time         `json:"initiated_at"`
-	StartedBy   string            `json:"started_by"`
-	StartedAt   time.Time         `json:"started_at"`
-	Result      *SwitchoverResult `json:"result"`
-	RunCount    int               `json:"run_count,omitempty"`
+	From             string            `json:"from"`
+	To               string            `json:"to"`
+	Cause            string            `json:"cause"`
+	InitiatedBy      string            `json:"initiated_by"`
+	InitiatedAt      time.Time         `json:"initiated_at"`
+	MasterTransition MasterTransition  `json:"master_transition"`
+	StartedBy        string            `json:"started_by"`
+	StartedAt        time.Time         `json:"started_at"`
+	Result           *SwitchoverResult `json:"result"`
+	RunCount         int               `json:"run_count,omitempty"`
 }
 
 func (sw *Switchover) String() string {

--- a/tests/features/failover.84.feature
+++ b/tests/features/failover.84.feature
@@ -25,6 +25,7 @@ Feature: failover
         {
           "cause": "auto",
           "from": "mysql1",
+          "master_transition": "failover",
           "result": {
             "ok": true
           }
@@ -124,6 +125,7 @@ Feature: failover
         {
             "cause": "auto",
             "from": "mysql1",
+            "master_transition": "failover",
             "result": {
                 "ok": true
             }
@@ -168,6 +170,7 @@ Feature: failover
         {
           "cause": "auto",
           "from": "mysql1",
+          "master_transition": "failover",
           "result": {
             "ok": true
           }
@@ -252,6 +255,7 @@ Feature: failover
         {
           "cause": "auto",
           "from": "mysql1",
+          "master_transition": "failover",
           "result": {
             "ok": true
           }
@@ -310,6 +314,7 @@ Feature: failover
         {
           "cause": "auto",
           "from": "mysql1",
+          "master_transition": "failover",
           "result": {
             "ok": true
           }
@@ -431,6 +436,7 @@ Feature: failover
     {
       "cause": "auto",
       "from": "mysql1",
+      "master_transition": "failover",
       "result": {
         "ok": true
       }

--- a/tests/features/failover.feature
+++ b/tests/features/failover.feature
@@ -25,6 +25,7 @@ Feature: failover
         {
           "cause": "auto",
           "from": "mysql1",
+          "master_transition": "failover",
           "result": {
             "ok": true
           }
@@ -124,6 +125,7 @@ Feature: failover
         {
             "cause": "auto",
             "from": "mysql1",
+            "master_transition": "failover",
             "result": {
                 "ok": true
             }
@@ -168,6 +170,7 @@ Feature: failover
         {
           "cause": "auto",
           "from": "mysql1",
+          "master_transition": "failover",
           "result": {
             "ok": true
           }
@@ -252,6 +255,7 @@ Feature: failover
         {
           "cause": "auto",
           "from": "mysql1",
+          "master_transition": "failover",
           "result": {
             "ok": true
           }
@@ -310,6 +314,7 @@ Feature: failover
         {
           "cause": "auto",
           "from": "mysql1",
+          "master_transition": "failover",
           "result": {
             "ok": true
           }
@@ -431,6 +436,7 @@ Feature: failover
     {
       "cause": "auto",
       "from": "mysql1",
+      "master_transition": "failover",
       "result": {
         "ok": true
       }

--- a/tests/features/readonly_filesystem.feature
+++ b/tests/features/readonly_filesystem.feature
@@ -1,5 +1,5 @@
 Feature: readonly filesystem
-  Scenario: check master failure when disk on muster become readonly
+  Scenario: check master failure when disk on master become readonly
     Given cluster environment is
         """
         MYSYNC_FAILOVER=true

--- a/tests/features/switchover_from.84.feature
+++ b/tests/features/switchover_from.84.feature
@@ -21,6 +21,7 @@ Feature: manual switchover from old master
       """
       {
         "from": "mysql1"
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_rejected_switch" should match json within "30" seconds
@@ -30,6 +31,7 @@ Feature: manual switchover from old master
           "to": "",
           "cause": "manual",
           "initiated_by": "REGEXP:.*@mysql1",
+          "master_transition": "switchover",
           "result": {
               "ok": false,
               "error": "no quorum, have 0 replicas while 2 is required"
@@ -56,7 +58,8 @@ Feature: manual switchover from old master
           "to": "",
           "cause": "manual",
           "initiated_by": "mysql1",
-          "run_count": 1
+          "run_count": 1,
+          "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_switch" should not exist within "30" seconds  
@@ -70,6 +73,7 @@ Feature: manual switchover from old master
           "to": "",
           "cause": "manual",
           "initiated_by": "mysql1",
+          "master_transition": "switchover",
           "result": {
               "ok": true
           }
@@ -107,13 +111,15 @@ Feature: manual switchover from old master
     And zookeeper node "/test/switch" should match json
       """
       {
-        "from": "mysql1"
+        "from": "mysql1",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_switch" should match json within "30" seconds
       """
       {
         "from": "mysql1",
+        "master_transition": "switchover",
         "result": {
           "ok": true
         }
@@ -182,6 +188,7 @@ Feature: manual switchover from old master
       """
       {
         "from": "mysql1",
+        "master_transition": "switchover",
         "result": {
           "ok": true
         }
@@ -229,7 +236,7 @@ Feature: manual switchover from old master
       """
     When I run command on host "mysql2"
       """
-      mysync switch --from mysql1 --wait=0s --force
+      mysync switch --from mysql1 --wait=0s --failover
       """
     Then command return code should be "0"
     And command output should match regexp
@@ -239,13 +246,15 @@ Feature: manual switchover from old master
     And zookeeper node "/test/switch" should match json
       """
       {
-        "from": "mysql1"
+        "from": "mysql1",
+        "master_transition": "failover"
       }
       """
     Then zookeeper node "/test/last_switch" should match json within "30" seconds
       """
       {
         "from": "mysql1",
+        "master_transition": "failover",
         "result": {
           "ok": true
         }
@@ -306,13 +315,15 @@ Feature: manual switchover from old master
     And zookeeper node "/test/switch" should match json
       """
       {
-        "from": "mysql1"
+        "from": "mysql1",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_rejected_switch" should match json within "30" seconds
       """
       {
         "from": "mysql1",
+        "master_transition": "switchover",
         "result": {
           "ok": false,
           "error": "switchover: failed to set old master mysql1 read-only switchover: failed to ping host mysql1"

--- a/tests/features/switchover_from.84.feature
+++ b/tests/features/switchover_from.84.feature
@@ -229,7 +229,7 @@ Feature: manual switchover from old master
       """
     When I run command on host "mysql2"
       """
-      mysync switch --from mysql1 --wait=0s
+      mysync switch --from mysql1 --wait=0s --force
       """
     Then command return code should be "0"
     And command output should match regexp
@@ -278,3 +278,48 @@ Feature: manual switchover from old master
     And mysql host "mysql1" should have variable "rpl_semi_sync_master_enabled" set to "0"
     And mysql replication on host "mysql1" should run fine within "10" seconds
     And mysql host "mysql1" should be read only
+
+  Scenario: switchover from does not work with dead master
+    Given cluster is up and running
+    Then zookeeper node "/test/active_nodes" should match json_exactly within "20" seconds
+      """
+      ["mysql1","mysql2","mysql3"]
+      """
+    When host "mysql1" is stopped
+    Then mysql host "mysql1" should become unavailable within "10" seconds
+    And mysql host "mysql2" should be replica of "mysql1"
+    And mysql host "mysql3" should be replica of "mysql1"
+    And I wait for "20" seconds
+    And zookeeper node "/test/active_nodes" should match json_exactly
+      """
+      ["mysql1","mysql2","mysql3"]
+      """
+    When I run command on host "mysql2"
+      """
+      mysync switch --from mysql1 --wait=0s
+      """
+    Then command return code should be "0"
+    And command output should match regexp
+      """
+      switchover scheduled
+      """
+    And zookeeper node "/test/switch" should match json
+      """
+      {
+        "from": "mysql1"
+      }
+      """
+    Then zookeeper node "/test/last_rejected_switch" should match json within "30" seconds
+      """
+      {
+        "from": "mysql1",
+        "result": {
+          "ok": false,
+          "error": "switchover: failed to set old master mysql1 read-only switchover: failed to ping host mysql1"
+        }
+      }
+
+      """
+    When I get zookeeper node "/test/master"
+    And I save zookeeper query result as "new_master"
+    Then mysql host "{{.new_master}}" should become unavailable within "10" seconds

--- a/tests/features/switchover_from.84.feature
+++ b/tests/features/switchover_from.84.feature
@@ -20,7 +20,7 @@ Feature: manual switchover from old master
     And zookeeper node "/test/switch" should match json
       """
       {
-        "from": "mysql1"
+        "from": "mysql1",
         "master_transition": "switchover"
       }
       """

--- a/tests/features/switchover_from.feature
+++ b/tests/features/switchover_from.feature
@@ -20,7 +20,8 @@ Feature: manual switchover from old master
     And zookeeper node "/test/switch" should match json
       """
       {
-        "from": "mysql1"
+        "from": "mysql1",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_rejected_switch" should match json within "30" seconds
@@ -30,6 +31,7 @@ Feature: manual switchover from old master
           "to": "",
           "cause": "manual",
           "initiated_by": "REGEXP:.*@mysql1",
+          "master_transition": "switchover",
           "result": {
               "ok": false,
               "error": "no quorum, have 0 replicas while 2 is required"
@@ -56,7 +58,8 @@ Feature: manual switchover from old master
           "to": "",
           "cause": "manual",
           "initiated_by": "mysql1",
-          "run_count": 1
+          "run_count": 1,
+          "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_switch" should not exist within "30" seconds  
@@ -70,6 +73,7 @@ Feature: manual switchover from old master
           "to": "",
           "cause": "manual",
           "initiated_by": "mysql1",
+          "master_transition": "switchover",
           "result": {
               "ok": true
           }
@@ -107,13 +111,15 @@ Feature: manual switchover from old master
     And zookeeper node "/test/switch" should match json
       """
       {
-        "from": "mysql1"
+        "from": "mysql1",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_switch" should match json within "30" seconds
       """
       {
         "from": "mysql1",
+        "master_transition": "switchover",
         "result": {
           "ok": true
         }
@@ -182,6 +188,7 @@ Feature: manual switchover from old master
       """
       {
         "from": "mysql1",
+        "master_transition": "switchover",
         "result": {
           "ok": true
         }
@@ -239,13 +246,15 @@ Feature: manual switchover from old master
     And zookeeper node "/test/switch" should match json
       """
       {
-        "from": "mysql1"
+         "from": "mysql1",
+         "master_transition": "failover"
       }
       """
     Then zookeeper node "/test/last_switch" should match json within "30" seconds
       """
       {
         "from": "mysql1",
+        "master_transition": "failover",
         "result": {
           "ok": true
         }
@@ -306,13 +315,15 @@ Feature: manual switchover from old master
     And zookeeper node "/test/switch" should match json
       """
       {
-        "from": "mysql1"
+        "from": "mysql1",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_rejected_switch" should match json within "30" seconds
       """
       {
         "from": "mysql1",
+        "master_transition": "switchover",
         "result": {
           "ok": false,
           "error": "switchover: failed to set old master mysql1 read-only switchover: failed to ping host mysql1"

--- a/tests/features/switchover_from.feature
+++ b/tests/features/switchover_from.feature
@@ -229,7 +229,7 @@ Feature: manual switchover from old master
       """
     When I run command on host "mysql2"
       """
-      mysync switch --from mysql1 --wait=0s
+      mysync switch --from mysql1 --wait=0s --failover
       """
     Then command return code should be "0"
     And command output should match regexp
@@ -278,3 +278,48 @@ Feature: manual switchover from old master
     And mysql host "mysql1" should have variable "rpl_semi_sync_master_enabled" set to "0"
     And mysql replication on host "mysql1" should run fine within "10" seconds
     And mysql host "mysql1" should be read only
+
+  Scenario: switchover from does not work with dead master
+    Given cluster is up and running
+    Then zookeeper node "/test/active_nodes" should match json_exactly within "20" seconds
+      """
+      ["mysql1","mysql2","mysql3"]
+      """
+    When host "mysql1" is stopped
+    Then mysql host "mysql1" should become unavailable within "10" seconds
+    And mysql host "mysql2" should be replica of "mysql1"
+    And mysql host "mysql3" should be replica of "mysql1"
+    And I wait for "20" seconds
+    And zookeeper node "/test/active_nodes" should match json_exactly
+      """
+      ["mysql1","mysql2","mysql3"]
+      """
+    When I run command on host "mysql2"
+      """
+      mysync switch --from mysql1 --wait=0s
+      """
+    Then command return code should be "0"
+    And command output should match regexp
+      """
+      switchover scheduled
+      """
+    And zookeeper node "/test/switch" should match json
+      """
+      {
+        "from": "mysql1"
+      }
+      """
+    Then zookeeper node "/test/last_rejected_switch" should match json within "30" seconds
+      """
+      {
+        "from": "mysql1",
+        "result": {
+          "ok": false,
+          "error": "switchover: failed to set old master mysql1 read-only switchover: failed to ping host mysql1"
+        }
+      }
+
+      """
+    When I get zookeeper node "/test/master"
+    And I save zookeeper query result as "new_master"
+    Then mysql host "{{.new_master}}" should become unavailable within "10" seconds

--- a/tests/features/switchover_to.feature
+++ b/tests/features/switchover_to.feature
@@ -198,7 +198,69 @@ Feature: manual switchover to new master
       | false    |
 
 
-  Scenario: switchover to works with dead master
+  Scenario: failover to works with dead master
+    Given cluster is up and running
+    Then zookeeper node "/test/active_nodes" should match json_exactly within "30" seconds
+      """
+      ["mysql1","mysql2","mysql3"]
+      """
+    And host "mysql1" is stopped
+    Then mysql host "mysql1" should become unavailable within "10" seconds
+    And mysql host "mysql2" should be replica of "mysql1"
+    And mysql host "mysql3" should be replica of "mysql1"
+    And I wait for "20" seconds
+    And zookeeper node "/test/active_nodes" should match json_exactly
+      """
+      ["mysql1","mysql2","mysql3"]
+      """
+    When I run command on host "mysql2"
+      """
+      mysync switch --to mysql2 --wait=0s --failover
+      """
+    Then command return code should be "0"
+    And command output should match regexp
+      """
+      switchover scheduled
+      """
+    And zookeeper node "/test/switch" should match json
+      """
+      {
+        "from": "",
+        "to": "mysql2",
+        "master_transition": "failover"
+      }
+      """
+    Then zookeeper node "/test/last_switch" should match json within "30" seconds
+      """
+      {
+        "from": "",
+        "to": "mysql2",
+        "master_transition": "failover",
+        "result": {
+          "ok": true
+        }
+      }
+      """
+    Then mysql host "mysql2" should be master
+    And mysql host "mysql2" should have variable "rpl_semi_sync_master_enabled" set to "1"
+    And mysql host "mysql2" should have variable "rpl_semi_sync_slave_enabled" set to "0"
+    And mysql host "mysql2" should be writable
+    And mysql host "mysql1" should become unavailable within "10" seconds
+    And mysql host "mysql3" should be replica of "mysql2"
+    And mysql host "mysql3" should have variable "rpl_semi_sync_slave_enabled" set to "1"
+    And mysql host "mysql3" should have variable "rpl_semi_sync_master_enabled" set to "0"
+    And mysql replication on host "mysql3" should run fine within "3" seconds
+    And mysql host "mysql3" should be read only
+
+    When host "mysql1" is started
+    Then mysql host "mysql1" should become available within "20" seconds
+    And mysql host "mysql1" should become replica of "mysql2" within "10" seconds
+    And mysql host "mysql1" should have variable "rpl_semi_sync_slave_enabled" set to "1" within "10" seconds
+    And mysql host "mysql1" should have variable "rpl_semi_sync_master_enabled" set to "0"
+    And mysql replication on host "mysql1" should run fine within "3" seconds
+    And mysql host "mysql1" should be read only
+
+  Scenario: switchover to does not work with dead master
     Given cluster is up and running
     Then zookeeper node "/test/active_nodes" should match json_exactly within "30" seconds
       """
@@ -230,36 +292,18 @@ Feature: manual switchover to new master
         "master_transition": "switchover"
       }
       """
-    Then zookeeper node "/test/last_switch" should match json within "30" seconds
+    Then zookeeper node "/test/last_rejected_switch" should match json within "30" seconds
       """
       {
         "from": "",
         "to": "mysql2",
         "master_transition": "switchover",
         "result": {
-          "ok": true
+          "ok": false,
+          "error": "switchover: failed to set old master mysql1 read-only switchover: failed to ping host mysql1"
         }
       }
-
       """
-    Then mysql host "mysql2" should be master
-    And mysql host "mysql2" should have variable "rpl_semi_sync_master_enabled" set to "1"
-    And mysql host "mysql2" should have variable "rpl_semi_sync_slave_enabled" set to "0"
-    And mysql host "mysql2" should be writable
-    And mysql host "mysql1" should become unavailable within "10" seconds
-    And mysql host "mysql3" should be replica of "mysql2"
-    And mysql host "mysql3" should have variable "rpl_semi_sync_slave_enabled" set to "1"
-    And mysql host "mysql3" should have variable "rpl_semi_sync_master_enabled" set to "0"
-    And mysql replication on host "mysql3" should run fine within "3" seconds
-    And mysql host "mysql3" should be read only
-
-    When host "mysql1" is started
-    Then mysql host "mysql1" should become available within "20" seconds
-    And mysql host "mysql1" should become replica of "mysql2" within "10" seconds
-    And mysql host "mysql1" should have variable "rpl_semi_sync_slave_enabled" set to "1" within "10" seconds
-    And mysql host "mysql1" should have variable "rpl_semi_sync_master_enabled" set to "0"
-    And mysql replication on host "mysql1" should run fine within "3" seconds
-    And mysql host "mysql1" should be read only
 
   Scenario: switchover on lagging replica fails
     Given cluster environment is

--- a/tests/features/switchover_to.feature
+++ b/tests/features/switchover_to.feature
@@ -30,7 +30,8 @@ Feature: manual switchover to new master
       """
       {
         "from": "",
-        "to": "mysql2"
+        "to": "mysql2",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_switch" should match json within "120" seconds
@@ -38,6 +39,7 @@ Feature: manual switchover to new master
       {
         "from": "",
         "to": "mysql2",
+        "master_transition": "switchover",
         "result": {
           "ok": true
         }
@@ -91,7 +93,8 @@ Feature: manual switchover to new master
       """
       {
         "from": "",
-        "to": "mysql2"
+        "to": "mysql2",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_switch" should match json within "30" seconds
@@ -99,6 +102,7 @@ Feature: manual switchover to new master
       {
         "from": "",
         "to": "mysql2",
+        "master_transition": "switchover"
         "result": {
           "ok": true
         }
@@ -153,7 +157,8 @@ Feature: manual switchover to new master
       """
       {
         "from": "",
-        "to": "mysql2"
+        "to": "mysql2",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_switch" should match json within "30" seconds
@@ -161,6 +166,7 @@ Feature: manual switchover to new master
       {
         "from": "",
         "to": "mysql2",
+        "master_transition": "switchover",
         "result": {
           "ok": true
         }
@@ -220,7 +226,8 @@ Feature: manual switchover to new master
       """
       {
         "from": "",
-        "to": "mysql2"
+        "to": "mysql2",
+        "master_transition": "switchover"
       }
       """
     Then zookeeper node "/test/last_switch" should match json within "30" seconds
@@ -228,6 +235,7 @@ Feature: manual switchover to new master
       {
         "from": "",
         "to": "mysql2",
+        "master_transition": "switchover",
         "result": {
           "ok": true
         }

--- a/tests/features/switchover_to.feature
+++ b/tests/features/switchover_to.feature
@@ -102,7 +102,7 @@ Feature: manual switchover to new master
       {
         "from": "",
         "to": "mysql2",
-        "master_transition": "switchover"
+        "master_transition": "switchover",
         "result": {
           "ok": true
         }

--- a/tests/features/zk_failure.feature
+++ b/tests/features/zk_failure.feature
@@ -65,7 +65,7 @@ Feature: mysync handles zookeeper lost
     And mysql host "mysql3" should be read only
 
 
-  Scenario: failover works when old muster is stuck waiting semisync ack
+  Scenario: failover works when old master hangs waiting semisync ack
     Given cluster environment is
     """
     MYSYNC_FAILOVER=false
@@ -110,12 +110,13 @@ Feature: mysync handles zookeeper lost
     # start manual deterministic switchover - we will use this in last check
     When I run command on host "mysql2"
     """
-        mysync switch --from mysql1 --wait=0s
+        mysync switch --from mysql1 --wait=0s --failover
     """
     Then zookeeper node "/test/last_switch" should match json within "90" seconds
     """
           {
             "from": "mysql1",
+            "master_transition": "switchover",
             "result": {
               "ok": true
             }

--- a/tests/features/zk_failure.feature
+++ b/tests/features/zk_failure.feature
@@ -116,7 +116,7 @@ Feature: mysync handles zookeeper lost
     """
           {
             "from": "mysql1",
-            "master_transition": "switchover",
+            "master_transition": "failover",
             "result": {
               "ok": true
             }


### PR DESCRIPTION
# Pull request description

### Describe what this PR fix

During an unstable network, the old master might repeatedly become available and then unavailable. This leads to an inconsistency between the `clusterState` (derived from MySQL) and the `activeNodes` (from Zookeeper). Specifically, if the old master is not included in the `frozenActiveNodes` set, it will not participate in the catch-up process. As a result, the new master might not have all the data that was on the old master, which can eventually lead to a split-brain scenario.

To prevent this, we could add transition type to the switchover mechanism. Switchover requires the master to be alive during the process, whereas failover does not. If an error occurs while setting the old master to read-only mode during switchover, we must reject the switchover. During failover, however, we must ignore the master's state because it is presumed unavailable.