### PR TITLE
Don’t abort HA update on inactive-node failures

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1194,21 +1194,21 @@ func (app *App) updateActiveNodes(clusterState, clusterStateDcs map[string]*Node
 		}
 	}
 
-  // Inactive nodes may be inaccessible
-  inactiveNodesError := []error{}
+	// Inactive nodes may be inaccessible
+	inactiveNodesError := []error{}
 
 	for _, host := range becomeInactive {
 		err = app.disableSemiSyncOnSlave(host, true)
 		if err != nil {
-      inactiveNodesError = append(inactiveNodesError, fmt.Errorf("[%s]: %s", host, err))
+			inactiveNodesError = append(inactiveNodesError, fmt.Errorf("[%s]: %s", host, err))
 			continue
 		}
 	}
 	for _, host := range becomeDataLag {
 		err = app.disableSemiSyncOnSlave(host, false)
 		if err != nil {
-      inactiveNodesError = append(inactiveNodesError, fmt.Errorf("[%s]: %s", host, err))
-      continue
+			inactiveNodesError = append(inactiveNodesError, fmt.Errorf("[%s]: %s", host, err))
+			continue
 		}
 
 		node := app.cluster.Get(host)
@@ -1218,9 +1218,9 @@ func (app *App) updateActiveNodes(clusterState, clusterStateDcs map[string]*Node
 		}
 	}
 
-  if len(inactiveNodesError) > 0 {
-    app.logger.Warnf("cannot disable semisync on inactive hosts: %s", err)
-  }
+	if len(inactiveNodesError) > 0 {
+		app.logger.Warnf("cannot disable semisync on inactive hosts: %s", err)
+	}
 
 	// enlarge HA-group, if needed (and if possible)
 	for _, hostname := range becomeActive {


### PR DESCRIPTION
# Pull request description

### Describe what this PR fix

The problem scenario is
1. Mysync attempted to remove REPLICA from HA.
2. It disabled semi-sync on REPLICA.
3. It tried to restart replication on REPLICA.
4. Replication was already stopped, but context deadline exceeded - this interrupted the master’s semi-sync update logic.
5. Mysync then automatically re-enabled replication on REPLICA.  
6. SOURCE waited for an ACK from REPLICA, which was no longer using semi-sync.

Since inactive nodes may legitimately be unreachable, we now collect their errors and place to the logs instead of interrupting HA-update logic.

### Please add config and mysync logs for debug purpose

```bash

DEBUG: node REPLICA running query 'START REPLICA FOR CHANNEL ''' with args <nil>, result: <nil>, error: context deadline exceeded
ERROR: repair: failed to start replication on REPLICA: context deadline exceeded
DEBUG: <gtid query was ignored>
ERROR: calc active nodes: REPLICA is not replicating or splitbrained, deleting from active...
INFO: update active nodes: active nodes are: [SOURCE], wait_slave_count 0
INFO: update active nodes: slave leave HA-group: [REPLICA]
INFO: update active nodes: master change wait_slave_count: 1 => 0
DEBUG: node SOURCE running query 'SELECT 1 AS Ok' with args struct {}{}, result: &mysql.pingResult{Ok:1}, error: <nil>
DEBUG: node REPLICA running query 'SET GLOBAL rpl_semi_sync_slave_enabled = 0, rpl_semi_sync_master_enabled = 0' with args map[string]interface {}{}, result: <nil>, error: <nil>
DEBUG: node REPLICA running query 'STOP REPLICA IO_THREAD FOR CHANNEL ''' with args <nil>, result: <nil>, error: context deadline exceeded
ERROR: failed restart slave io thread after set semi_sync_slave on REPLICA: context deadline exceeded
ERROR: failed to update active nodes in dcs: context deadline exceeded
INFO: mysync state: Manager
DEBUG: node SOURCE running query 'SELECT 1 AS Ok' with args struct {}{}, result: &mysql.pingResult{Ok:1}, error: <nil>
DEBUG: node SOURCE running query 'SELECT @@read_only AS ReadOnly, @@super_read_only AS SuperReadOnly' with args struct {}{}, result: &mysql.readOnlyResult{ReadOnly:0, SuperReadOnly:0}, error: <nil>
DEBUG: node SOURCE running query 'SELECT @@GLOBAL.offline_mode AS OfflineMode' with args struct {}{}, result: &mysql.offlineModeStatus{OfflineMode:0}, error: <nil>
DEBUG: <gtid query was ignored>
DEBUG: <gtid query was ignored>
DEBUG: node SOURCE running query 'SELECT @@rpl_semi_sync_master_enabled AS MasterEnabled, @@rpl_semi_sync_slave_enabled AS SlaveEnabled, @@rpl_semi_sync_master_wait_for_slave_count as WaitSlaveCount' with args struct {}{}, result: &mysql.SemiSyncStatus{MasterEnabled:1, SlaveEnabled:0, WaitSlaveCount:1}, error: <nil>
INFO: healthcheck: <ping=ok repl=master sync=m1- ro=false offline=false lag=0.00 du=60.90% cr=no gtid=08dda108-4c6f-11f0-a1b1-d00d1643275f:1-44846,2a5e5bcb-f0cb-11ee-999b-d00d12aa6052:1-41345445>
INFO: HA nodes: [SOURCE REPLICA]
INFO: cascade nodes: []
DEBUG: node SOURCE running query 'SELECT 1 AS Ok' with args struct {}{}, result: &mysql.pingResult{Ok:1}, error: <nil>
DEBUG: node SOURCE running query 'SELECT @@read_only AS ReadOnly, @@super_read_only AS SuperReadOnly' with args struct {}{}, result: &mysql.readOnlyResult{ReadOnly:0, SuperReadOnly:0}, error: <nil>
DEBUG: node SOURCE running query 'SELECT @@GLOBAL.offline_mode AS OfflineMode' with args struct {}{}, result: &mysql.offlineModeStatus{OfflineMode:0}, error: <nil>
DEBUG: <gtid query was ignored>
DEBUG: <gtid query was ignored>
DEBUG: node SOURCE running query 'SELECT @@rpl_semi_sync_master_enabled AS MasterEnabled, @@rpl_semi_sync_slave_enabled AS SlaveEnabled, @@rpl_semi_sync_master_wait_for_slave_count as WaitSlaveCount' with args struct {}{}, result: &mysql.SemiSyncStatus{MasterEnabled:1, SlaveEnabled:0, WaitSlaveCount:1}, error: <nil>
DEBUG: node REPLICA running query 'SELECT 1 AS Ok' with args struct {}{}, result: &mysql.pingResult{Ok:1}, error: <nil>
DEBUG: node REPLICA running query 'SELECT @@read_only AS ReadOnly, @@super_read_only AS SuperReadOnly' with args struct {}{}, result: &mysql.readOnlyResult{ReadOnly:1, SuperReadOnly:1}, error: <nil>
DEBUG: node REPLICA running query 'SELECT @@GLOBAL.offline_mode AS OfflineMode' with args struct {}{}, result: &mysql.offlineModeStatus{OfflineMode:0}, error: <nil>
DEBUG: <gtid query was ignored>
DEBUG: node REPLICA running query 'SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) - UNIX_TIMESTAMP(ts) AS Seconds_Behind_Master FROM mdb_repl_mon' with args struct {}{}, result: &mysql.replicationLag{Lag:sql.NullFloat64{Float64:9.857, Valid:true}}, error: <nil>
DEBUG: node REPLICA running query 'SELECT @@rpl_semi_sync_master_enabled AS MasterEnabled, @@rpl_semi_sync_slave_enabled AS SlaveEnabled, @@rpl_semi_sync_master_wait_for_slave_count as WaitSlaveCount' with args struct {}{}, result: &mysql.SemiSyncStatus{MasterEnabled:0, SlaveEnabled:0, WaitSlaveCount:1}, error: <nil>

```