### PR TITLE
MasterTransition may not be specified

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1410,7 +1410,8 @@ func (app *App) performSwitchover(clusterState map[string]*NodeState, activeNode
 	}, activeNodes)
 
 	// if master was not among activeNodes - there will be no key in errs
-	if err, ok := errs[oldMaster]; ok && err != nil && switchover.MasterTransition == SwitchoverTransition {
+	// MasterTransition may not be set if issued from worker
+	if err, ok := errs[oldMaster]; ok && err != nil && switchover.MasterTransition != FailoverTransition {
 		err = fmt.Errorf("switchover: failed to set old master %s read-only %s", oldMaster, err)
 		app.logger.Info(err.Error())
 		switchErr := app.FinishSwitchover(switchover, err)


### PR DESCRIPTION
# MasterTransition may not be specified

If MasterTransition is not specified - we may leave old master not read-only, that will cause splitbrain