### PR TITLE
Optimization hotfix: change the order to disabling the node before deleting the DCS node

### DIFF
--- a/internal/app/optimization/utility.go
+++ b/internal/app/optimization/utility.go
@@ -30,11 +30,11 @@ func disableHostWithDCS(
 	rs mysql.ReplicationSettings,
 	DCS dcs.DCS,
 ) error {
-	err := DCS.Delete(dcs.JoinPath(pathOptimizationNodes, node.Host()))
+	err := node.SetReplicationSettings(rs)
 	if err != nil {
 		return err
 	}
-	return node.SetReplicationSettings(rs)
+	return DCS.Delete(dcs.JoinPath(pathOptimizationNodes, node.Host()))
 }
 
 func isOptimal(


### PR DESCRIPTION
Deleting a DCS node first carries a risk of leaking optimized replication status if an error occurs while disabling optimization. This may cause unexpected data loss during a crash.