### PR TITLE
fix: log switchover timing properly

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1383,8 +1383,7 @@ func (app *App) performSwitchover(clusterState map[string]*nodestate.NodeState, 
 		}
 	}
 
-	// downtime for failover starts at master loss (see IssueFailover); for switchover it starts here
-	if switchover.MasterTransition == SwitchoverTransition {
+	if switchover.MasterTransition != FailoverTransition {
 		app.startTiming(timingDowntime, time.Time{})
 	}
 

--- a/internal/app/app_dcs.go
+++ b/internal/app/app_dcs.go
@@ -151,7 +151,7 @@ func (app *App) FinishSwitchover(switchover *Switchover, switchErr error) error 
 
 	if switchErr != nil {
 		app.logSwitchoverFailure(switchover)
-	} else if switchover.MasterTransition == SwitchoverTransition {
+	} else if switchover.MasterTransition != FailoverTransition {
 		app.stopTiming(timingSwitchover)
 	} else {
 		app.stopTiming(timingFailover)
@@ -179,7 +179,7 @@ func (app *App) StartSwitchover(switchover *Switchover) error {
 	app.logger.Info().Msgf("switchover: %s => %s starting...", switchover.From, switchover.To)
 	switchover.StartedAt = time.Now()
 	switchover.StartedBy = app.config.Hostname
-	if switchover.MasterTransition == SwitchoverTransition {
+	if switchover.MasterTransition != FailoverTransition {
 		app.startTiming(timingSwitchover, switchover.InitiatedAt)
 	}
 	return app.dcs.Set(pathCurrentSwitch, switchover)

--- a/internal/app/timing_tracker.go
+++ b/internal/app/timing_tracker.go
@@ -62,7 +62,7 @@ func (app *App) stopTiming(name string) {
 // Marker-guarded so it is logged once, and only when the switchover actually started.
 func (app *App) logSwitchoverFailure(sw *Switchover) {
 	now := time.Now()
-	if sw.MasterTransition != SwitchoverTransition {
+	if sw.MasterTransition == FailoverTransition {
 		return
 	}
 	start, ok := app.getTimingStart(timingSwitchover)

--- a/tests/features/timings.feature
+++ b/tests/features/timings.feature
@@ -32,6 +32,10 @@ Feature: failover and switchover timings are logged via log_timing command
       """
     Then command output should match regexp
       """
+      failover:
+      """
+    And command output should match regexp
+      """
       downtime:
       """
 
@@ -65,6 +69,51 @@ Feature: failover and switchover timings are logged via log_timing command
       cat /tmp/timing.log
       """
     Then command output should match regexp
+      """
+      switchover:
+      """
+    And command output should match regexp
+      """
+      downtime:
+      """
+
+  Scenario: switchover issued externally without master_transition logs switchover timing
+    Given cluster is up and running
+    Then mysql host "mysql1" should be master
+    And zookeeper node "/test/active_nodes" should match json_exactly within "30" seconds
+      """
+      ["mysql1","mysql2","mysql3"]
+      """
+    When I set zookeeper node "/test/switch" to
+      """
+      {
+          "from": "mysql1",
+          "to": "mysql2",
+          "cause": "manual",
+          "initiated_by": "worker"
+      }
+      """
+    Then zookeeper node "/test/last_switch" should match json within "120" seconds
+      """
+      {
+          "to": "mysql2",
+          "result": {
+              "ok": true
+          }
+      }
+      """
+    Then mysql host "mysql2" should be master
+    When I get zookeeper node "/test/manager"
+    And I save zookeeper query result as "manager"
+    When I run command on host "{{.manager.hostname}}" until result match regexp "switchover:" with timeout "30" seconds
+      """
+      cat /tmp/timing.log
+      """
+    Then command output should match regexp
+      """
+      switchover:
+      """
+    And command output should match regexp
       """
       downtime:
       """


### PR DESCRIPTION
When we set switchover externally, we need to handle this case properly