### PR TITLE
Make semi-sync adjustment reversed order

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1026,8 +1026,22 @@ func (app *App) updateActiveNodes(clusterState, clusterStateDcs map[string]*node
 		return err
 	}
 
-	// first, shrink HA-group, if needed
-	if waitSlaveCount > oldWaitSlaveCount {
+	// When ReversedAdjustSSOrder is true (recommended):
+	//   before replicas: shrink (waitSlaveCount < oldWaitSlaveCount) — lower the ack requirement first
+	//   after replicas:  enlarge (waitSlaveCount > oldWaitSlaveCount) — raise it only after replicas are ready
+	// This avoids deadlocks where the master blocks waiting for acks from replicas
+	// that haven't switched to semi-sync mode yet.
+	//
+	// When ReversedAdjustSSOrder is false (legacy default):
+	//   before replicas: enlarge (waitSlaveCount > oldWaitSlaveCount)
+	//   after replicas:  shrink (waitSlaveCount < oldWaitSlaveCount)
+	adjustBefore := waitSlaveCount < oldWaitSlaveCount
+	adjustAfter := waitSlaveCount > oldWaitSlaveCount
+	if !app.config.ReversedAdjustSSOrder {
+		adjustBefore, adjustAfter = adjustAfter, adjustBefore
+	}
+
+	if adjustBefore {
 		err := app.adjustSemiSyncOnMaster(masterNode, masterState, waitSlaveCount)
 		if err != nil {
 			app.logger.Error().Err(err).Msgf("failed to adjust semi-sync on master %s to %d", masterNode.Host(), waitSlaveCount)
@@ -1040,7 +1054,6 @@ func (app *App) updateActiveNodes(clusterState, clusterStateDcs map[string]*node
 		app.logger.Warn().Msgf("cannot disable semisync on inactive hosts: %s", err)
 	}
 
-	// enlarge HA-group, if needed (and if possible)
 	for _, hostname := range becomeActive {
 		err := app.enableSemiSyncOnSlave(hostname, clusterState[hostname], masterState)
 		if err != nil {
@@ -1055,7 +1068,7 @@ func (app *App) updateActiveNodes(clusterState, clusterStateDcs map[string]*node
 			app.logger.Error().Err(err).Msgf("failed to set default replication settings %s", hostname)
 		}
 	}
-	if waitSlaveCount < oldWaitSlaveCount {
+	if adjustAfter {
 		err := app.adjustSemiSyncOnMaster(masterNode, masterState, waitSlaveCount)
 		if err != nil {
 			app.logger.Error().Err(err).Msgf("failed to adjust semi-sync on master %s to %d", masterNode.Host(), waitSlaveCount)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1026,18 +1026,18 @@ func (app *App) updateActiveNodes(clusterState, clusterStateDcs map[string]*node
 		return err
 	}
 
-	// When ReversedAdjustSSOrder is true (recommended):
-	//   before replicas: shrink (waitSlaveCount < oldWaitSlaveCount) — lower the ack requirement first
+	// When MasterFirstAdjustSSOrder is true (recommended):
+	//   before replicas: shrink (waitSlaveCount < oldWaitSlaveCount) — lower the ack requirement on master first
 	//   after replicas:  enlarge (waitSlaveCount > oldWaitSlaveCount) — raise it only after replicas are ready
 	// This avoids deadlocks where the master blocks waiting for acks from replicas
 	// that haven't switched to semi-sync mode yet.
 	//
-	// When ReversedAdjustSSOrder is false (legacy default):
+	// When MasterFirstAdjustSSOrder is false (legacy default):
 	//   before replicas: enlarge (waitSlaveCount > oldWaitSlaveCount)
 	//   after replicas:  shrink (waitSlaveCount < oldWaitSlaveCount)
 	adjustBefore := waitSlaveCount < oldWaitSlaveCount
 	adjustAfter := waitSlaveCount > oldWaitSlaveCount
-	if !app.config.ReversedAdjustSSOrder {
+	if !app.config.MasterFirstAdjustSSOrder {
 		adjustBefore, adjustAfter = adjustAfter, adjustBefore
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,7 +87,7 @@ type Config struct {
 	PriorityChoiceMaxLag                    time.Duration                `config:"priority_choice_max_lag" yaml:"priority_choice_max_lag"`
 	TestDiskUsageFile                       string                       `config:"test_disk_usage_file" yaml:"test_disk_usage_file"`
 	RplSemiSyncMasterWaitForSlaveCount      int                          `config:"rpl_semi_sync_master_wait_for_slave_count" yaml:"rpl_semi_sync_master_wait_for_slave_count"`
-	ReversedAdjustSSOrder                   bool                         `config:"reversed_adjust_ss_order" yaml:"reversed_adjust_ss_order"`
+	MasterFirstAdjustSSOrder                bool                         `config:"master_first_adjust_ss_order" yaml:"master_first_adjust_ss_order"`
 	WaitReplicationStartTimeout             time.Duration                `config:"wait_start_replication_timeout" yaml:"wait_start_replication_timeout"`
 	ReplicationRepairAggressiveMode         bool                         `config:"replication_repair_aggressive_mode" yaml:"replication_repair_aggressive_mode"`
 	ReplicationRepairCooldown               time.Duration                `config:"replication_repair_cooldown" yaml:"replication_repair_cooldown"`
@@ -192,7 +192,7 @@ func DefaultConfig() (Config, error) {
 		PriorityChoiceMaxLag:                    60 * time.Second,
 		TestDiskUsageFile:                       "", // fake disk usage, only for docker tests
 		RplSemiSyncMasterWaitForSlaveCount:      1,
-		ReversedAdjustSSOrder:                   false,
+		MasterFirstAdjustSSOrder:                false,
 		WaitReplicationStartTimeout:             10 * time.Second,
 		ReplicationRepairAggressiveMode:         false,
 		ReplicationRepairCooldown:               1 * time.Minute,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,7 @@ type Config struct {
 	PriorityChoiceMaxLag                    time.Duration                `config:"priority_choice_max_lag" yaml:"priority_choice_max_lag"`
 	TestDiskUsageFile                       string                       `config:"test_disk_usage_file" yaml:"test_disk_usage_file"`
 	RplSemiSyncMasterWaitForSlaveCount      int                          `config:"rpl_semi_sync_master_wait_for_slave_count" yaml:"rpl_semi_sync_master_wait_for_slave_count"`
+	ReversedAdjustSSOrder                   bool                         `config:"reversed_adjust_ss_order" yaml:"reversed_adjust_ss_order"`
 	WaitReplicationStartTimeout             time.Duration                `config:"wait_start_replication_timeout" yaml:"wait_start_replication_timeout"`
 	ReplicationRepairAggressiveMode         bool                         `config:"replication_repair_aggressive_mode" yaml:"replication_repair_aggressive_mode"`
 	ReplicationRepairCooldown               time.Duration                `config:"replication_repair_cooldown" yaml:"replication_repair_cooldown"`
@@ -191,6 +192,7 @@ func DefaultConfig() (Config, error) {
 		PriorityChoiceMaxLag:                    60 * time.Second,
 		TestDiskUsageFile:                       "", // fake disk usage, only for docker tests
 		RplSemiSyncMasterWaitForSlaveCount:      1,
+		ReversedAdjustSSOrder:                   false,
 		WaitReplicationStartTimeout:             10 * time.Second,
 		ReplicationRepairAggressiveMode:         false,
 		ReplicationRepairCooldown:               1 * time.Minute,

--- a/tests/images/mysql/mysync.yaml
+++ b/tests/images/mysql/mysync.yaml
@@ -43,7 +43,7 @@ commands:
   log_timing: 'echo "%s: %s" >> /tmp/timing.log'
 disable_semi_sync_replication_on_maintenance: ${MYSYNC_DISABLE_REPLICATION_ON_MAINT:-false}
 rpl_semi_sync_master_wait_for_slave_count: ${MYSYNC_WAIT_FOR_SLAVE_COUNT:-1}
-reversed_adjust_ss_order: ${MYSYNC_REVERSED_ADJUST_SS_ORDER:-true}
+master_first_adjust_ss_order: ${MYSYNC_MASTER_FIRST_ADJUST_SS_ORDER:-true}
 critical_disk_usage: ${MYSYNC_CRITICAL_DISK_USAGE:-100}
 keep_super_writable_on_critical_disk_usage: ${MYSYNC_KEEP_SUPER_WRITABLE_ON_CRITICAL_DISK_USAGE:-false}
 test_disk_usage_file: /tmp/usedspace

--- a/tests/images/mysql/mysync.yaml
+++ b/tests/images/mysql/mysync.yaml
@@ -43,6 +43,7 @@ commands:
   log_timing: 'echo "%s: %s" >> /tmp/timing.log'
 disable_semi_sync_replication_on_maintenance: ${MYSYNC_DISABLE_REPLICATION_ON_MAINT:-false}
 rpl_semi_sync_master_wait_for_slave_count: ${MYSYNC_WAIT_FOR_SLAVE_COUNT:-1}
+reversed_adjust_ss_order: ${MYSYNC_REVERSED_ADJUST_SS_ORDER:-true}
 critical_disk_usage: ${MYSYNC_CRITICAL_DISK_USAGE:-100}
 keep_super_writable_on_critical_disk_usage: ${MYSYNC_KEEP_SUPER_WRITABLE_ON_CRITICAL_DISK_USAGE:-false}
 test_disk_usage_file: /tmp/usedspace

--- a/tests/images/mysql_jepsen/mysync.yaml
+++ b/tests/images/mysql_jepsen/mysync.yaml
@@ -30,6 +30,7 @@ mysql:
   port: $MYSQL_PORT
   pid_file: /tmp/mysqld.pid
 disable_semi_sync_replication_on_maintenance: ${MYSYNC_DISABLE_REPLICATION_ON_MAINT:-false}
+reversed_adjust_ss_order: ${MYSYNC_REVERSED_ADJUST_SS_ORDER:-true}
 replication_channel: ''
 test_filesystem_readonly_file: /tmp/readonly
 test_disk_usage_file: /tmp/usedspace

--- a/tests/images/mysql_jepsen/mysync.yaml
+++ b/tests/images/mysql_jepsen/mysync.yaml
@@ -30,7 +30,7 @@ mysql:
   port: $MYSQL_PORT
   pid_file: /tmp/mysqld.pid
 disable_semi_sync_replication_on_maintenance: ${MYSYNC_DISABLE_REPLICATION_ON_MAINT:-false}
-reversed_adjust_ss_order: ${MYSYNC_REVERSED_ADJUST_SS_ORDER:-true}
+master_first_adjust_ss_order: ${MYSYNC_MASTER_FIRST_ADJUST_SS_ORDER:-true}
 replication_channel: ''
 test_filesystem_readonly_file: /tmp/readonly
 test_disk_usage_file: /tmp/usedspace


### PR DESCRIPTION
# Pull request description

### Describe what this PR fix
MySQL may deadlock while executing grant commands and adjusting semi-sync settings

Reversed mode introdused to avoid this problem.

Only in tests now