### PR TITLE
fix wait optimization

### DIFF
--- a/internal/app/optimization/controller.go
+++ b/internal/app/optimization/controller.go
@@ -2,6 +2,7 @@ package optimization
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,6 +11,10 @@ import (
 	"github.com/yandex/mysync/internal/mysql"
 	"github.com/yandex/mysync/internal/util"
 )
+
+// ErrDeadlineExceeded is returned by Wait when the context deadline is reached before
+// the replica converges. Callers (e.g. optimizationPhase) use errors.Is to detect this.
+var ErrDeadlineExceeded = errors.New("optimization waiting deadline exceeded")
 
 func NewController(
 	config config.OptimizationConfig,
@@ -43,7 +48,7 @@ func (m *Controller) Wait(ctx context.Context, node Node) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("optimization waiting deadline exceeded")
+			return ErrDeadlineExceeded
 
 		case <-ticker.C:
 			isOptimized, err := m.isOptimizedDuringWaiting(node)
@@ -84,7 +89,7 @@ func (m *Controller) isOptimizedDuringWaiting(node Node) (bool, error) {
 	}
 
 	lag := replicationStatus.GetReplicationLag()
-	if lag.Valid && lag.Float64 < float64(m.config.LowReplicationMark) {
+	if lag.Valid && lag.Float64 < m.config.LowReplicationMark.Seconds() {
 		m.logger.Info().Msgf("optimization: waiting is complete, as replication lag is converged: %v", lag.Float64)
 		return true, m.dcs.DeleteHosts(node.Host())
 	}

--- a/internal/app/optimization/controller.go
+++ b/internal/app/optimization/controller.go
@@ -70,11 +70,13 @@ func (m *Controller) isOptimizedDuringWaiting(node Node) (bool, error) {
 	if dcsState == nil {
 		return true, nil
 	}
-	if dcsState.Status == StatusEnabled {
-		m.logger.Info().Msg("optimization: waiting; node is optimizing")
-	} else {
-		return true, nil
+	if dcsState.Status != StatusEnabled {
+		// StatusNew: Syncer has not yet applied optimization settings — keep waiting
+		m.logger.Info().Msg("optimization: waiting; optimization not yet started")
+		return false, nil
 	}
+
+	m.logger.Info().Msg("optimization: waiting; node is optimizing")
 
 	replicationStatus, err := node.GetReplicaStatus()
 	if err != nil {

--- a/internal/app/optimization/controller_test.go
+++ b/internal/app/optimization/controller_test.go
@@ -2,6 +2,7 @@ package optimization
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -74,7 +75,7 @@ func TestWaitOptimization(t *testing.T) {
 		manager := NewController(defaultConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Wait(ctx, node)
-		require.EqualError(t, err, "optimization waiting deadline exceeded")
+		require.True(t, errors.Is(err, ErrDeadlineExceeded), "expected ErrDeadlineExceeded, got: %v", err)
 	})
 
 	t.Run("StatusNew keeps waiting until Syncer transitions to StatusEnabled", func(t *testing.T) {
@@ -105,12 +106,7 @@ func TestWaitOptimization(t *testing.T) {
 
 	t.Run("Waiting works", func(t *testing.T) {
 		ctx := context.Background()
-		// Small nanosecond thresholds so the lag values (4.0, 200.0, 800.0)
-		// are compared as raw nanoseconds, forcing Wait() to iterate multiple times.
-		cfg := config.OptimizationConfig{
-			LowReplicationMark:  5,   // 5 ns
-			HighReplicationMark: 120, // 120 ns
-		}
+		// LowReplicationMark=5s: lags 800s and 200s fail the check, 4s passes → 3 iterations.
 		checkInterval := time.Nanosecond
 
 		ctrl := gomock.NewController(t)
@@ -125,7 +121,7 @@ func TestWaitOptimization(t *testing.T) {
 			Return(&DCSState{Status: "enabled"}, nil).AnyTimes()
 		Dcs.EXPECT().DeleteHosts("replica1")
 
-		manager := NewController(cfg, &logger, Dcs, checkInterval)
+		manager := NewController(defaultConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Wait(ctx, node)
 		require.NoError(t, err)

--- a/internal/app/optimization/controller_test.go
+++ b/internal/app/optimization/controller_test.go
@@ -15,16 +15,17 @@ import (
 
 //nolint:funlen
 func TestWaitOptimization(t *testing.T) {
+	defaultConfig := config.OptimizationConfig{
+		LowReplicationMark:  5 * time.Second,
+		HighReplicationMark: 120 * time.Second,
+	}
+	logger := zerolog.Nop()
+	checkInterval := time.Millisecond
+
 	t.Run("Waiting for an optimized replica", func(t *testing.T) {
 		ctx := context.Background()
-		config := config.OptimizationConfig{
-			LowReplicationMark:  5 * time.Second,
-			HighReplicationMark: 120 * time.Second,
-		}
-		checkInterval := time.Millisecond
 
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		node := MakeNodeMock(ctrl, "replica1")
 		node.WithGetReplicaStatus(1.0)
@@ -34,12 +35,7 @@ func TestWaitOptimization(t *testing.T) {
 			Return(&DCSState{Status: "enabled"}, nil)
 		Dcs.EXPECT().DeleteHosts("replica1")
 
-		manager := NewController(
-			config,
-			&logger,
-			Dcs,
-			checkInterval,
-		)
+		manager := NewController(defaultConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Wait(ctx, node)
 		require.NoError(t, err)
@@ -47,14 +43,8 @@ func TestWaitOptimization(t *testing.T) {
 
 	t.Run("Waiting for a replica absent in DCS", func(t *testing.T) {
 		ctx := context.Background()
-		config := config.OptimizationConfig{
-			LowReplicationMark:  5 * time.Second,
-			HighReplicationMark: 120 * time.Second,
-		}
-		checkInterval := time.Millisecond
 
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		node := MakeNodeMock(ctrl, "replica1")
 
@@ -62,12 +52,7 @@ func TestWaitOptimization(t *testing.T) {
 		Dcs.EXPECT().GetState("replica1").
 			Return(nil, nil)
 
-		manager := NewController(
-			config,
-			&logger,
-			Dcs,
-			checkInterval,
-		)
+		manager := NewController(defaultConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Wait(ctx, node)
 		require.NoError(t, err)
@@ -77,43 +62,58 @@ func TestWaitOptimization(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 0)
 		defer cancel()
 
-		config := config.OptimizationConfig{
-			LowReplicationMark:  5 * time.Second,
-			HighReplicationMark: 120 * time.Second,
-		}
-		checkInterval := time.Millisecond
-
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		node := MakeNodeMock(ctrl, "replica1")
 		node.WithGetReplicaStatus(1024.0).AnyTimes()
 
 		Dcs := NewMockDCS(ctrl)
 		Dcs.EXPECT().GetState("replica1").
-			Return(&DCSState{Status: ""}, nil).AnyTimes()
+			Return(&DCSState{Status: StatusEnabled}, nil).AnyTimes()
 
-		manager := NewController(
-			config,
-			&logger,
-			Dcs,
-			checkInterval,
-		)
+		manager := NewController(defaultConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Wait(ctx, node)
 		require.EqualError(t, err, "optimization waiting deadline exceeded")
 	})
 
+	t.Run("StatusNew keeps waiting until Syncer transitions to StatusEnabled", func(t *testing.T) {
+		ctx := context.Background()
+		checkInterval := time.Nanosecond
+
+		ctrl := gomock.NewController(t)
+
+		node := MakeNodeMock(ctrl, "replica1")
+		node.WithGetReplicaStatus(4.0)
+
+		Dcs := NewMockDCS(ctrl)
+		gomock.InOrder(
+			// First tick: Syncer hasn't started yet — Status="" → keep waiting
+			Dcs.EXPECT().GetState("replica1").
+				Return(&DCSState{Status: StatusNew}, nil),
+			// Second tick: Syncer has applied settings — Status="enabled" → check lag
+			Dcs.EXPECT().GetState("replica1").
+				Return(&DCSState{Status: StatusEnabled}, nil),
+		)
+		Dcs.EXPECT().DeleteHosts("replica1")
+
+		manager := NewController(defaultConfig, &logger, Dcs, checkInterval)
+
+		err := manager.Wait(ctx, node)
+		require.NoError(t, err)
+	})
+
 	t.Run("Waiting works", func(t *testing.T) {
 		ctx := context.Background()
-		config := config.OptimizationConfig{
-			LowReplicationMark:  5,
-			HighReplicationMark: 120,
+		// Small nanosecond thresholds so the lag values (4.0, 200.0, 800.0)
+		// are compared as raw nanoseconds, forcing Wait() to iterate multiple times.
+		cfg := config.OptimizationConfig{
+			LowReplicationMark:  5,   // 5 ns
+			HighReplicationMark: 120, // 120 ns
 		}
 		checkInterval := time.Nanosecond
 
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		node := MakeNodeMock(ctrl, "replica1")
 		node.WithGetReplicaStatus(800.0)
@@ -125,12 +125,7 @@ func TestWaitOptimization(t *testing.T) {
 			Return(&DCSState{Status: "enabled"}, nil).AnyTimes()
 		Dcs.EXPECT().DeleteHosts("replica1")
 
-		manager := NewController(
-			config,
-			&logger,
-			Dcs,
-			checkInterval,
-		)
+		manager := NewController(cfg, &logger, Dcs, checkInterval)
 
 		err := manager.Wait(ctx, node)
 		require.NoError(t, err)
@@ -138,21 +133,19 @@ func TestWaitOptimization(t *testing.T) {
 }
 
 func TestEnableNodeOptimization(t *testing.T) {
+	emptyConfig := config.OptimizationConfig{}
+	checkInterval := time.Second
+	logger := zerolog.Nop()
+
 	t.Run("Enable on a replica", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		node := MakeNodeMock(ctrl, "replica1")
 
 		Dcs := NewMockDCS(ctrl)
 		Dcs.EXPECT().CreateHosts("replica1")
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Enable(node)
 		require.NoError(t, err)
@@ -160,7 +153,6 @@ func TestEnableNodeOptimization(t *testing.T) {
 
 	t.Run("Network error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		node := MakeNodeMock(ctrl, "replica1")
 
@@ -168,12 +160,7 @@ func TestEnableNodeOptimization(t *testing.T) {
 		Dcs.EXPECT().CreateHosts("replica1").
 			Return(fmt.Errorf("network-error"))
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Enable(node)
 		require.EqualError(t, err, "network-error")
@@ -181,9 +168,12 @@ func TestEnableNodeOptimization(t *testing.T) {
 }
 
 func TestDisableNodeOptimization(t *testing.T) {
+	emptyConfig := config.OptimizationConfig{}
+	checkInterval := time.Second
+	logger := zerolog.Nop()
+
 	t.Run("Disable a replica", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		master := MakeNodeMock(ctrl, "master")
 		master.WithGetReplicationSettings()
@@ -194,12 +184,7 @@ func TestDisableNodeOptimization(t *testing.T) {
 		Dcs := NewMockDCS(ctrl)
 		Dcs.EXPECT().DeleteHosts("replica1")
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Disable(master, node)
 		require.NoError(t, err)
@@ -207,7 +192,6 @@ func TestDisableNodeOptimization(t *testing.T) {
 
 	t.Run("Network error on the side of DCS", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		master := MakeNodeMock(ctrl, "master")
 		master.WithGetReplicationSettings()
@@ -219,12 +203,7 @@ func TestDisableNodeOptimization(t *testing.T) {
 		Dcs.EXPECT().DeleteHosts("replica1").
 			Return(fmt.Errorf("network-error"))
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Disable(master, node)
 		require.EqualError(t, err, "network-error")
@@ -232,7 +211,6 @@ func TestDisableNodeOptimization(t *testing.T) {
 
 	t.Run("Network error on the side of MySQL", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		master := MakeNodeMock(ctrl, "master")
 		master.EXPECT().GetReplicationSettings().
@@ -245,12 +223,7 @@ func TestDisableNodeOptimization(t *testing.T) {
 		Dcs.EXPECT().DeleteHosts("replica1").
 			Return(fmt.Errorf("network-error"))
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.Disable(master, node)
 		require.EqualError(t, err, "network-error")
@@ -259,9 +232,12 @@ func TestDisableNodeOptimization(t *testing.T) {
 
 //nolint:funlen
 func TestDisableAllNodeOptimization(t *testing.T) {
+	emptyConfig := config.OptimizationConfig{}
+	checkInterval := time.Second
+	logger := zerolog.Nop()
+
 	t.Run("Disable all replicas", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		master := MakeNodeMock(ctrl, "master")
 		master.WithGetReplicationSettings()
@@ -278,12 +254,7 @@ func TestDisableAllNodeOptimization(t *testing.T) {
 		Dcs.EXPECT().DeleteHosts("replica1")
 		Dcs.EXPECT().DeleteHosts("replica2")
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.DisableAll(master, []Node{replica1, replica2})
 		require.NoError(t, err)
@@ -291,7 +262,6 @@ func TestDisableAllNodeOptimization(t *testing.T) {
 
 	t.Run("Disable only one replica", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		master := MakeNodeMock(ctrl, "master")
 		master.WithGetReplicationSettings()
@@ -304,12 +274,7 @@ func TestDisableAllNodeOptimization(t *testing.T) {
 			Return([]string{"replica1", "replica2"}, nil)
 		Dcs.EXPECT().DeleteHosts("replica1")
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.DisableAll(master, []Node{replica1})
 		require.NoError(t, err)
@@ -317,7 +282,6 @@ func TestDisableAllNodeOptimization(t *testing.T) {
 
 	t.Run("DCS network-errors", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		master := MakeNodeMock(ctrl, "master")
 		master.WithGetReplicationSettings()
@@ -336,12 +300,7 @@ func TestDisableAllNodeOptimization(t *testing.T) {
 		Dcs.EXPECT().DeleteHosts("replica2").
 			Return(fmt.Errorf("network-error"))
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.DisableAll(master, []Node{replica1, replica2})
 		require.EqualError(t, err, "got the following errors: replica1:network-error,replica2:network-error")
@@ -349,7 +308,6 @@ func TestDisableAllNodeOptimization(t *testing.T) {
 
 	t.Run("MySQL network-errors", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		logger := zerolog.Nop()
 
 		master := MakeNodeMock(ctrl, "master")
 		master.EXPECT().GetReplicationSettings().Return(mysql.ReplicationSettings{}, fmt.Errorf("network-error"))
@@ -366,12 +324,7 @@ func TestDisableAllNodeOptimization(t *testing.T) {
 		Dcs.EXPECT().DeleteHosts("replica1")
 		Dcs.EXPECT().DeleteHosts("replica2")
 
-		manager := NewController(
-			config.OptimizationConfig{},
-			&logger,
-			Dcs,
-			time.Second,
-		)
+		manager := NewController(emptyConfig, &logger, Dcs, checkInterval)
 
 		err := manager.DisableAll(master, []Node{replica1, replica2})
 		require.NoError(t, err)

--- a/internal/app/optimization/syncer.go
+++ b/internal/app/optimization/syncer.go
@@ -166,6 +166,11 @@ func (s *Syncer) startNodes(
 		if err != nil {
 			return err
 		}
+		// Mark as actively optimizing so Wait() knows to start checking replication lag
+		err = s.dcs.SetState(host, &DCSState{Status: StatusEnabled})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/app/optimization/syncer_test.go
+++ b/internal/app/optimization/syncer_test.go
@@ -256,6 +256,67 @@ func TestHAClusterOptimization(t *testing.T) {
 	})
 }
 
+func TestStartNodesSetStatusEnabled(t *testing.T) {
+	t.Run("startNodes sets StatusEnabled in DCS after OptimizeReplication", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		logger := zerolog.Nop()
+
+		config := config.OptimizationConfig{
+			LowReplicationMark:  5 * time.Second,
+			HighReplicationMark: 120 * time.Second,
+		}
+
+		master := NewMockNode(ctrl)
+		master.EXPECT().GetReplicationSettings().
+			Return(mysql.ReplicationSettings{InnodbFlushLogAtTrxCommit: 1, SyncBinlog: 1}, nil).AnyTimes()
+
+		// replica has same settings as master (not optimized yet) and high lag → DisabledHosts
+		replica1 := NewMockNode(ctrl)
+		replica1.EXPECT().GetReplicationSettings().
+			Return(mysql.ReplicationSettings{InnodbFlushLogAtTrxCommit: 1, SyncBinlog: 1}, nil).AnyTimes()
+		replica1.EXPECT().OptimizeReplication()
+
+		cluster := NewMockCluster(ctrl)
+		cluster.EXPECT().GetMaster().
+			Return("master").AnyTimes()
+		cluster.EXPECT().GetNode("master").
+			Return(master).AnyTimes()
+		cluster.EXPECT().GetState("master").
+			Return(nodestate.NodeState{
+				ReplicationSettings: &mysql.ReplicationSettings{
+					InnodbFlushLogAtTrxCommit: 1,
+					SyncBinlog:                1,
+				},
+			}).AnyTimes()
+
+		cluster.EXPECT().GetNode("replica1").
+			Return(replica1).AnyTimes()
+		cluster.EXPECT().GetState("replica1").
+			Return(nodestate.NodeState{
+				ReplicationSettings: &mysql.ReplicationSettings{
+					InnodbFlushLogAtTrxCommit: 1,
+					SyncBinlog:                1,
+				},
+				SlaveState: &nodestate.SlaveState{
+					ReplicationLag: util.Ptr(1024.0), // high lag → not near-converged → DisabledHosts
+				},
+			}).AnyTimes()
+
+		Dcs := NewMockDCS(ctrl)
+		Dcs.EXPECT().GetHosts().
+			Return([]string{"replica1"}, nil)
+		// Status="" (StatusNew) → DisabledHosts branch in getClusterHostsState
+		Dcs.EXPECT().GetState("replica1").
+			Return(&DCSState{Status: StatusNew}, nil)
+		// startNodes must set StatusEnabled after OptimizeReplication
+		Dcs.EXPECT().SetState("replica1", &DCSState{Status: StatusEnabled})
+
+		opt := NewSyncer(&logger, config, Dcs)
+		err := opt.Sync(cluster)
+		require.NoError(t, err)
+	})
+}
+
 func TestOneHostOptimizationPolicy(t *testing.T) {
 	t.Run("Optimization can be enabled on just one host", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/internal/app/replication.go
+++ b/internal/app/replication.go
@@ -419,6 +419,15 @@ func (app *App) optimizationPhase(
 	appropriateReplicas := filterOut(activeNodes, []string{oldMaster, switchover.From})
 	desirableReplica := switchover.To
 
+	lowMark := app.config.OptimizationConfig.LowReplicationMark.Seconds()
+	if replica, lag, ok := anyReplicaConverged(appropriateReplicas, clusterState, lowMark); ok {
+		app.logger.Info().Msgf(
+			"switchover: phase 0: turbo mode is skipped: replica '%s' already has low lag: %.2f s",
+			replica, lag,
+		)
+		return nil
+	}
+
 	app.logger.Info().Msgf(
 		"switchover: phase 0: enter turbo mode; replicas: %v, oldMaster: '%s', desirable replica: '%s'",
 		appropriateReplicas,
@@ -452,4 +461,23 @@ func (app *App) optimizationPhase(
 	// Other cases can be handled in subsequent steps, so no special action is needed here.
 	app.logger.Info().Msg("switchover: phase 0: turbo mode is complete")
 	return nil
+}
+
+// anyReplicaConverged returns the first replica whose replication lag is below lowMark seconds.
+// Returns (hostname, lag, true) when found, or ("", 0, false) when none qualifies.
+func anyReplicaConverged(
+	replicas []string,
+	clusterState map[string]*nodestate.NodeState,
+	lowMark float64,
+) (string, float64, bool) {
+	for _, replica := range replicas {
+		state := clusterState[replica]
+		if state == nil || state.SlaveState == nil || state.SlaveState.ReplicationLag == nil {
+			continue
+		}
+		if lag := *state.SlaveState.ReplicationLag; lag < lowMark {
+			return replica, lag, true
+		}
+	}
+	return "", 0, false
 }

--- a/internal/app/replication.go
+++ b/internal/app/replication.go
@@ -431,10 +431,21 @@ func (app *App) optimizationPhase(
 	desirableReplica := switchover.To
 
 	lowMark := app.config.OptimizationConfig.LowReplicationMark.Seconds()
-	if replica, lag, ok := anyReplicaConverged(appropriateReplicas, clusterState, lowMark); ok {
+	var skipReplica string
+	var skipLag float64
+	if desirableReplica != "" {
+		// When a specific target is set, check only that replica.
+		if lag, ok := replicaConverged(clusterState, desirableReplica, lowMark); ok {
+			skipReplica, skipLag = desirableReplica, lag
+		}
+	} else {
+		// When no target is set, optimization picks the replica with the smallest lag.
+		skipReplica, skipLag, _ = anyReplicaConverged(appropriateReplicas, clusterState, lowMark)
+	}
+	if skipReplica != "" {
 		app.logger.Info().Msgf(
 			"switchover: phase 0: turbo mode is skipped: replica '%s' already has low lag: %.2f s",
-			replica, lag,
+			skipReplica, skipLag,
 		)
 		return nil
 	}
@@ -456,7 +467,7 @@ func (app *App) optimizationPhase(
 		desirableReplica,
 		clusterAdapter,
 	)
-	if err != nil && errors.Is(err, ErrOptimizationPhaseDeadlineExceeded) {
+	if err != nil && errors.Is(err, optimization.ErrDeadlineExceeded) {
 		app.logger.Info().Msgf("switchover: phase 0: turbo mode failed: %v", err)
 		switchErr := app.FinishSwitchover(switchover, fmt.Errorf("turbo mode exceeded deadline"))
 		if switchErr != nil {
@@ -474,6 +485,20 @@ func (app *App) optimizationPhase(
 	return nil
 }
 
+// replicaConverged reports whether the given replica's replication lag is known and below lowMark seconds.
+// Returns (lag, true) when converged, (0, false) otherwise.
+func replicaConverged(clusterState map[string]*nodestate.NodeState, replica string, lowMark float64) (float64, bool) {
+	state := clusterState[replica]
+	if state == nil || state.SlaveState == nil || state.SlaveState.ReplicationLag == nil {
+		return 0, false
+	}
+	lag := *state.SlaveState.ReplicationLag
+	if lag < lowMark {
+		return lag, true
+	}
+	return 0, false
+}
+
 // masterUnreachable reports whether the old master is absent from clusterState or failed its ping.
 func masterUnreachable(clusterState map[string]*nodestate.NodeState, master string) bool {
 	state := clusterState[master]
@@ -488,11 +513,7 @@ func anyReplicaConverged(
 	lowMark float64,
 ) (string, float64, bool) {
 	for _, replica := range replicas {
-		state := clusterState[replica]
-		if state == nil || state.SlaveState == nil || state.SlaveState.ReplicationLag == nil {
-			continue
-		}
-		if lag := *state.SlaveState.ReplicationLag; lag < lowMark {
+		if lag, ok := replicaConverged(clusterState, replica, lowMark); ok {
 			return replica, lag, true
 		}
 	}

--- a/internal/app/replication.go
+++ b/internal/app/replication.go
@@ -416,6 +416,17 @@ func (app *App) optimizationPhase(
 		return nil
 	}
 
+	// Turbo mode requires the Syncer to read replication settings from the master.
+	// If the master is unreachable, Sync() will fail and optimization will never start,
+	// causing Wait() to block until the deadline. Skip turbo mode in that case.
+	if masterUnreachable(clusterState, oldMaster) {
+		app.logger.Info().Msgf(
+			"switchover: phase 0: turbo mode is skipped: old master '%s' is not available",
+			oldMaster,
+		)
+		return nil
+	}
+
 	appropriateReplicas := filterOut(activeNodes, []string{oldMaster, switchover.From})
 	desirableReplica := switchover.To
 
@@ -461,6 +472,12 @@ func (app *App) optimizationPhase(
 	// Other cases can be handled in subsequent steps, so no special action is needed here.
 	app.logger.Info().Msg("switchover: phase 0: turbo mode is complete")
 	return nil
+}
+
+// masterUnreachable reports whether the old master is absent from clusterState or failed its ping.
+func masterUnreachable(clusterState map[string]*nodestate.NodeState, master string) bool {
+	state := clusterState[master]
+	return state == nil || !state.PingOk
 }
 
 // anyReplicaConverged returns the first replica whose replication lag is below lowMark seconds.

--- a/internal/app/replication_test.go
+++ b/internal/app/replication_test.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	nodestate "github.com/yandex/mysync/internal/app/node_state"
 	"github.com/yandex/mysync/internal/config"
 	"github.com/yandex/mysync/internal/mysql"
+	"github.com/yandex/mysync/internal/util"
 )
 
 type fakeExternalReplicationSourceStatus struct {
@@ -91,4 +93,75 @@ func TestExternalReplicationRepairOrderWithSingleAttempt(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ChangeSource, algorithm)
 	require.Zero(t, count)
+}
+
+func TestAnyReplicaConverged(t *testing.T) {
+	lowMark := 5.0 // seconds
+
+	makeState := func(lag *float64) *nodestate.NodeState {
+		return &nodestate.NodeState{
+			SlaveState: &nodestate.SlaveState{
+				ReplicationLag: lag,
+			},
+		}
+	}
+
+	t.Run("returns false when replica list is empty", func(t *testing.T) {
+		_, _, ok := anyReplicaConverged(nil, nil, lowMark)
+		require.False(t, ok)
+	})
+
+	t.Run("returns false when all replicas have high lag", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{
+			"replica1": makeState(util.Ptr(100.0)),
+			"replica2": makeState(util.Ptr(50.0)),
+		}
+		_, _, ok := anyReplicaConverged([]string{"replica1", "replica2"}, state, lowMark)
+		require.False(t, ok)
+	})
+
+	t.Run("returns false when replica has no lag info", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{
+			"replica1": makeState(nil),
+		}
+		_, _, ok := anyReplicaConverged([]string{"replica1"}, state, lowMark)
+		require.False(t, ok)
+	})
+
+	t.Run("returns false when replica state is nil", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{
+			"replica1": nil,
+		}
+		_, _, ok := anyReplicaConverged([]string{"replica1"}, state, lowMark)
+		require.False(t, ok)
+	})
+
+	t.Run("returns true for replica with lag below low mark", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{
+			"replica1": makeState(util.Ptr(100.0)),
+			"replica2": makeState(util.Ptr(3.0)),
+		}
+		host, lag, ok := anyReplicaConverged([]string{"replica1", "replica2"}, state, lowMark)
+		require.True(t, ok)
+		require.Equal(t, "replica2", host)
+		require.InDelta(t, 3.0, lag, 1e-9)
+	})
+
+	t.Run("lag equal to low mark is not converged", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{
+			"replica1": makeState(util.Ptr(5.0)),
+		}
+		_, _, ok := anyReplicaConverged([]string{"replica1"}, state, lowMark)
+		require.False(t, ok)
+	})
+
+	t.Run("returns the first converged replica in order", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{
+			"replica1": makeState(util.Ptr(1.0)),
+			"replica2": makeState(util.Ptr(2.0)),
+		}
+		host, _, ok := anyReplicaConverged([]string{"replica1", "replica2"}, state, lowMark)
+		require.True(t, ok)
+		require.Equal(t, "replica1", host)
+	})
 }

--- a/internal/app/replication_test.go
+++ b/internal/app/replication_test.go
@@ -94,6 +94,56 @@ func TestExternalReplicationRepairOrderWithSingleAttempt(t *testing.T) {
 	require.Equal(t, ChangeSource, algorithm)
 	require.Zero(t, count)
 }
+func TestReplicaConverged(t *testing.T) {
+	lowMark := 5.0
+
+	makeState := func(lag *float64) *nodestate.NodeState {
+		return &nodestate.NodeState{
+			SlaveState: &nodestate.SlaveState{ReplicationLag: lag},
+		}
+	}
+
+	t.Run("target with high lag returns false — turbo must not be skipped", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{
+			"replica1": makeState(util.Ptr(1.0)),   // low lag but NOT the target
+			"replica2": makeState(util.Ptr(100.0)), // target — high lag
+		}
+		// anyReplicaConverged would incorrectly find replica1 if called for both.
+		_, _, ok := anyReplicaConverged([]string{"replica1", "replica2"}, state, lowMark)
+		require.True(t, ok, "sanity: anyReplicaConverged finds replica1")
+
+		// replicaConverged checks only the designated target.
+		_, ok = replicaConverged(state, "replica2", lowMark)
+		require.False(t, ok, "target replica2 has high lag — turbo must NOT be skipped")
+	})
+
+	t.Run("target with low lag returns true — turbo should be skipped", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{
+			"replica1": makeState(util.Ptr(100.0)),
+			"replica2": makeState(util.Ptr(3.0)),
+		}
+		lag, ok := replicaConverged(state, "replica2", lowMark)
+		require.True(t, ok, "target replica2 already has low lag — turbo should be skipped")
+		require.InDelta(t, 3.0, lag, 1e-9)
+	})
+
+	t.Run("target absent from state returns false", func(t *testing.T) {
+		_, ok := replicaConverged(map[string]*nodestate.NodeState{}, "replica1", lowMark)
+		require.False(t, ok)
+	})
+
+	t.Run("target with nil lag returns false", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{"replica1": makeState(nil)}
+		_, ok := replicaConverged(state, "replica1", lowMark)
+		require.False(t, ok)
+	})
+
+	t.Run("lag equal to lowMark is not converged", func(t *testing.T) {
+		state := map[string]*nodestate.NodeState{"replica1": makeState(util.Ptr(5.0))}
+		_, ok := replicaConverged(state, "replica1", lowMark)
+		require.False(t, ok)
+	})
+}
 
 func TestAnyReplicaConverged(t *testing.T) {
 	lowMark := 5.0 // seconds

--- a/internal/app/util.go
+++ b/internal/app/util.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -12,8 +11,6 @@ import (
 	"github.com/yandex/mysync/internal/mysql"
 	"github.com/yandex/mysync/internal/mysql/gtids"
 )
-
-var ErrOptimizationPhaseDeadlineExceeded = errors.New("optimization phase: deadline exceeded")
 
 type nodePosition struct {
 	host     string


### PR DESCRIPTION
We may not wait optimization phase:

```
2026-08-28T06:03:20Z INFO  switchover: We will select most desirable node among these:
2026-08-28T06:03:20Z INFO  switchover: host: replica-1, priority: 0, lag: 19073.213000
2026-08-28T06:03:20Z INFO  switchover: host replica-1 selected as highest priority (no more recent hosts). Priority: 0, lag: 19073.2130
00 (maxLag 120.000000)
2026-08-28T06:03:20Z INFO  replica optimization: the replica is 'replica-1'
2026-08-28T06:03:23Z INFO  optimization: waiting is complete
2026-08-28T06:03:23Z INFO  switchover: phase 0: turbo mode is complete
2026-08-28T06:03:23Z INFO  optimization: <disabled: [replica-1], optimizing: [], optimized: [], malfunc: []>
2026-08-28T06:03:23Z INFO  optimization: start optimizing new node replica-1
2026-08-28T06:03:23Z DEBUG node replica-1 running query 'SET GLOBAL innodb_flush_log_at_trx_commit = :level' with args map[string]inter
face {}{"level":2}, result: <nil>, error: <nil>
2026-08-28T06:03:23Z DEBUG node replica-1 running query 'SET GLOBAL sync_binlog = :sync_binlog' with args map[string]interface {}{"sync
_binlog":1000}, result: <nil>, error: <nil>
2026-08-28T06:03:23Z INFO  switchover: phase 1: enter read only
```