### PR TITLE
metrics: fix failover rare metrics

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -531,7 +531,6 @@ func (app *App) stateManager() appState {
 			now := time.Now()
 			app.t.Set(NodeFailedAt, master, now)
 			app.startTiming(timingDowntime, now)
-			app.startTiming(timingFailover, now)
 		}
 		if lightMaintenance {
 			app.logger.Info().Msgf("failover suppressed by light maintenance mode")
@@ -552,7 +551,6 @@ func (app *App) stateManager() appState {
 	} else {
 		if !app.t.Get(NodeFailedAt, master).IsZero() {
 			app.stopTiming(timingDowntime)
-			app.stopTiming(timingFailover)
 			app.t.Clean(NodeFailedAt, master)
 		}
 	}

--- a/internal/app/app_dcs.go
+++ b/internal/app/app_dcs.go
@@ -141,7 +141,9 @@ func (app *App) FinishSwitchover(switchover *Switchover, switchErr error) error 
 		switchover.Result.Error = switchErr.Error()
 	}
 
-	if switchErr != nil {
+	if switchErr != nil && switchover.MasterTransition == FailoverTransition {
+		app.clearTiming(timingFailover)
+	} else if switchErr != nil {
 		app.logSwitchoverFailure(switchover)
 	} else if switchover.MasterTransition != FailoverTransition {
 		app.stopTiming(timingSwitchover)
@@ -218,7 +220,11 @@ func (app *App) IssueFailover(master string) error {
 		Cause:            CauseAuto,
 		MasterTransition: FailoverTransition,
 	}
-	return app.appDCS.CreateCurrentSwitchover(&switchover)
+	if err := app.appDCS.CreateCurrentSwitchover(&switchover); err != nil {
+		return err
+	}
+	app.startTiming(timingFailover, switchover.InitiatedAt)
+	return nil
 }
 
 // SetMasterHost writes the current master hostname to ZK.

--- a/internal/app/appdcs_test.go
+++ b/internal/app/appdcs_test.go
@@ -317,3 +317,28 @@ func TestGetCurrentMaster_NoMasterAnywhere(t *testing.T) {
 	_, err := app.getCurrentMaster(cs)
 	require.ErrorIs(t, err, ErrNoMaster)
 }
+
+func TestIssueFailoverStartsTiming(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDCS := NewMockIAppDCS(ctrl)
+	mockDCS.EXPECT().CreateCurrentSwitchover(gomock.Any()).Return(nil)
+
+	timingDCS := &timingDCSStub{}
+	app := newTestApp(t, minConfig(), mockDCS)
+	app.dcs = timingDCS
+
+	require.NoError(t, app.IssueFailover("master"))
+	require.True(t, timingDCS.started)
+}
+
+type timingDCSStub struct {
+	dcs.DCS
+	started bool
+}
+
+func (d *timingDCSStub) Set(string, any) error {
+	d.started = true
+	return nil
+}


### PR DESCRIPTION
Fix failover metrics count, now failover timer starts only after Failover is issued